### PR TITLE
Implement SQLite state persistence for update tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .pytest_cache/
 .venv/
 .coverage
+.DS_Store

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,7 @@ CRON_SCHEDULE     = os.environ.get("CRON_SCHEDULE", "0 * * * *")
 RUN_ON_STARTUP    = os.environ.get("RUN_ON_STARTUP", "true").lower() == "true"
 LABEL_PREFIX      = os.environ.get("LABEL_PREFIX", "docker-update-monitor")
 DRY_RUN           = os.environ.get("DRY_RUN", "false").lower() == "true"
+STATE_DB_PATH     = os.environ.get("STATE_DB_PATH", "/app/data/state.db")
 LOG_LEVEL         = os.environ.get("LOG_LEVEL", "INFO").upper()
 
 logging.basicConfig(

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -9,3 +9,4 @@ class UpdateInfo:
     current_version: str
     new_version: str
     update_type: str        # "patch" | "minor" | "major"
+    status: str = ""        # "new" | "known" | "resolved"

--- a/app/notifications/webhook.py
+++ b/app/notifications/webhook.py
@@ -6,11 +6,22 @@ import app.http as _http
 from app.models import UpdateInfo
 
 
+def _build_payload(updates: list[UpdateInfo]) -> dict:
+    """Group updates by status into a structured payload."""
+    grouped: dict[str, list[dict]] = {"new": [], "known": [], "resolved": []}
+    for u in updates:
+        entry = asdict(u)
+        del entry["status"]
+        grouped.setdefault(u.status, []).append(entry)
+    # Drop empty categories
+    return {k: v for k, v in grouped.items() if v}
+
+
 def notify(updates: list[UpdateInfo]) -> None:
     if not updates:
         return
 
-    payload = [asdict(u) for u in updates]
+    payload = _build_payload(updates)
 
     if _config.DRY_RUN:
         _config.log.info("DRY_RUN — would POST:\n" + json.dumps(payload, indent=2))

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime, timezone
 
 import docker
 from docker.errors import DockerException
@@ -9,6 +10,7 @@ from app.registry import fetch_all_tags
 from app.registry.dockerhub import get_dockerhub_token
 from app.version import find_updates
 from app.notifications.webhook import notify
+from app.state import process_scan, mark_notified
 
 
 def run_check() -> None:
@@ -112,5 +114,19 @@ def run_check() -> None:
                 ))
 
     _config.log.info("-" * 60)
-    _config.log.info(f"Check complete — {len(all_updates)} update(s) to report")
-    notify(all_updates)
+    _config.log.info(f"Check complete — {len(all_updates)} update(s) detected")
+
+    scan_time = datetime.now(timezone.utc)
+
+    # Persist state and categorize: new / known / resolved
+    categorized = process_scan(all_updates, scan_time)
+
+    new_count = sum(1 for u in categorized if u.status == "new")
+    known_count = sum(1 for u in categorized if u.status == "known")
+    resolved_count = sum(1 for u in categorized if u.status == "resolved")
+    _config.log.info(f"  New: {new_count}  |  Known: {known_count}  |  Resolved: {resolved_count}")
+
+    # Notify with all categorized updates (grouped by status in payload)
+    notify(categorized)
+    if categorized:
+        mark_notified(categorized, scan_time)

--- a/app/state.py
+++ b/app/state.py
@@ -1,0 +1,161 @@
+import sqlite3
+from copy import copy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import app.config as _config
+from app.models import UpdateInfo
+
+_DB_PATH = Path(_config.STATE_DB_PATH)
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS updates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    container_name TEXT NOT NULL,
+    image TEXT NOT NULL,
+    current_version TEXT NOT NULL,
+    new_version TEXT NOT NULL,
+    update_type TEXT NOT NULL,
+    stack TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    notified_at TEXT,
+    resolved_at TEXT,
+    UNIQUE(container_name, image, new_version, update_type)
+);
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(_DB_PATH))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(_SCHEMA)
+    conn.commit()
+    return conn
+
+
+def process_scan(updates: list[UpdateInfo], scan_time: datetime | None = None) -> list[UpdateInfo]:
+    """Upsert scan results, resolve absent entries, and return all updates with status set.
+
+    Returns a list of UpdateInfo with ``status`` set to ``"new"``, ``"known"``,
+    or ``"resolved"``.
+    """
+    if scan_time is None:
+        scan_time = datetime.now(timezone.utc)
+
+    ts = scan_time.isoformat()
+    conn = _connect()
+    try:
+        # --- upsert current findings ---
+        for u in updates:
+            conn.execute(
+                """INSERT INTO updates (container_name, image, current_version, new_version,
+                                        update_type, stack, first_seen_at, last_seen_at, resolved_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                   ON CONFLICT(container_name, image, new_version, update_type) DO UPDATE SET
+                       last_seen_at = excluded.last_seen_at,
+                       current_version = excluded.current_version,
+                       stack = excluded.stack,
+                       resolved_at = NULL""",
+                (u.container_name, u.image, u.current_version, u.new_version,
+                 u.update_type, u.stack, ts, ts),
+            )
+
+        # --- resolve absent entries ---
+        if not updates:
+            conn.execute(
+                "UPDATE updates SET resolved_at = ? WHERE resolved_at IS NULL",
+                (ts,),
+            )
+        else:
+            placeholders = ",".join(["(?, ?, ?, ?)"] * len(updates))
+            params: list[str] = []
+            for u in updates:
+                params.extend([u.container_name, u.image, u.new_version, u.update_type])
+
+            conn.execute(
+                f"""UPDATE updates SET resolved_at = ?
+                    WHERE resolved_at IS NULL
+                    AND (container_name, image, new_version, update_type) NOT IN
+                        (VALUES {placeholders})""",
+                [ts] + params,
+            )
+
+        conn.commit()
+
+        # --- build categorized result ---
+        conn.row_factory = sqlite3.Row
+
+        # Newly resolved in this scan
+        resolved_rows = conn.execute(
+            "SELECT * FROM updates WHERE resolved_at = ? ORDER BY first_seen_at",
+            (ts,),
+        ).fetchall()
+
+        # Active (non-resolved)
+        active_rows = conn.execute(
+            "SELECT * FROM updates WHERE resolved_at IS NULL ORDER BY first_seen_at",
+        ).fetchall()
+
+        result: list[UpdateInfo] = []
+
+        for row in active_rows:
+            status = "new" if row["first_seen_at"] == ts else "known"
+            result.append(UpdateInfo(
+                container_name=row["container_name"],
+                stack=row["stack"],
+                image=row["image"],
+                current_version=row["current_version"],
+                new_version=row["new_version"],
+                update_type=row["update_type"],
+                status=status,
+            ))
+
+        for row in resolved_rows:
+            result.append(UpdateInfo(
+                container_name=row["container_name"],
+                stack=row["stack"],
+                image=row["image"],
+                current_version=row["current_version"],
+                new_version=row["new_version"],
+                update_type=row["update_type"],
+                status="resolved",
+            ))
+
+        return result
+    finally:
+        conn.close()
+
+
+def mark_notified(updates: list[UpdateInfo], notified_time: datetime | None = None) -> None:
+    """Set notified_at for the given updates."""
+    if notified_time is None:
+        notified_time = datetime.now(timezone.utc)
+
+    ts = notified_time.isoformat()
+    conn = _connect()
+    try:
+        for u in updates:
+            conn.execute(
+                """UPDATE updates SET notified_at = ?
+                   WHERE container_name = ? AND image = ? AND new_version = ? AND update_type = ?
+                     AND notified_at IS NULL""",
+                (ts, u.container_name, u.image, u.new_version, u.update_type),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_active_updates() -> list[dict]:
+    """Return all non-resolved update rows as dicts."""
+    conn = _connect()
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT * FROM updates WHERE resolved_at IS NULL ORDER BY first_seen_at"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     volumes:
       # Read-only access to the Docker socket
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Persistent state database
+      - ./data:/app/data
 
     # Needed so 'nobody' user can access the Docker socket
     group_add:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,24 @@
 """Shared fixtures for the update-monitor test suite."""
 
+import os
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app import http as http_mod
 from app import main as main_mod
+
+
+@pytest.fixture(autouse=True)
+def _state_db_in_tmp(tmp_path):
+    """Redirect the state DB to a temp directory for every test."""
+    db_path = str(tmp_path / "state.db")
+    with patch("app.config.STATE_DB_PATH", db_path):
+        import app.state as state_mod
+        state_mod._DB_PATH = Path(db_path)
+        yield
 
 
 @pytest.fixture

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -18,6 +18,7 @@ def _make_update(**kwargs):
         current_version="1.0.0",
         new_version="1.1.0",
         update_type="minor",
+        status="new",
     )
     defaults.update(kwargs)
     return UpdateInfo(**defaults)
@@ -88,8 +89,10 @@ class TestNotifySuccessfulPost:
 
         mock_session.post.assert_called_once()
         call_kwargs = mock_session.post.call_args
-        assert call_kwargs[1]["json"][0]["container_name"] == "test-app"
-        assert call_kwargs[1]["json"][0]["new_version"] == "1.1.0"
+        payload = call_kwargs[1]["json"]
+        assert "new" in payload
+        assert payload["new"][0]["container_name"] == "test-app"
+        assert payload["new"][0]["new_version"] == "1.1.0"
 
     @patch.object(http_mod, "http_session")
     def test_successful_post_logs_count(self, mock_session, caplog):

--- a/tests/test_run_on_startup.py
+++ b/tests/test_run_on_startup.py
@@ -1,7 +1,7 @@
 """Unit tests for RUN_ON_STARTUP behavior in main()."""
 
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 import pytest
 
 from app import config as config_mod
@@ -28,3 +28,83 @@ class TestRunOnStartup:
             with pytest.raises(InterruptedError):
                 main_mod.main()
             mock_run_check.assert_not_called()
+
+    @patch("app.main.run_check")
+    def test_shutdown_during_startup_check_exits_immediately(self, mock_run_check):
+        """If shutdown is requested during the startup run_check, exit without entering the loop."""
+        def set_shutdown():
+            main_mod.shutdown_requested = True
+
+        mock_run_check.side_effect = set_shutdown
+
+        with patch.object(config_mod, "RUN_ON_STARTUP", True), \
+             pytest.raises(SystemExit) as exc_info:
+            main_mod.main()
+
+        assert exc_info.value.code == 0
+        mock_run_check.assert_called_once()
+
+
+class TestCronLoop:
+    """Tests covering the cron scheduling loop in main()."""
+
+    @patch("app.main.run_check")
+    @patch("app.main.time.sleep")
+    def test_cron_loop_runs_check_and_schedules_next(self, mock_sleep, mock_run_check):
+        """After wait expires, run_check is called and next_run is advanced."""
+        call_count = 0
+
+        def shutdown_after_first_check():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                main_mod.shutdown_requested = True
+
+        mock_run_check.side_effect = shutdown_after_first_check
+
+        with patch.object(config_mod, "RUN_ON_STARTUP", False), \
+             patch.object(config_mod, "CRON_SCHEDULE", "* * * * *"), \
+             pytest.raises(SystemExit) as exc_info:
+            main_mod.main()
+
+        assert exc_info.value.code == 0
+        mock_run_check.assert_called_once()
+
+    @patch("app.main.run_check")
+    @patch("app.main.time.sleep")
+    def test_cron_loop_shutdown_during_sleep(self, mock_sleep, mock_run_check):
+        """If shutdown is requested during the sleep loop, exits without calling run_check."""
+        def set_shutdown(*args):
+            main_mod.shutdown_requested = True
+
+        mock_sleep.side_effect = set_shutdown
+
+        with patch.object(config_mod, "RUN_ON_STARTUP", False), \
+             patch.object(config_mod, "CRON_SCHEDULE", "* * * * *"), \
+             pytest.raises(SystemExit) as exc_info:
+            main_mod.main()
+
+        assert exc_info.value.code == 0
+        mock_run_check.assert_not_called()
+
+    @patch("app.main.run_check")
+    @patch("app.main.time.sleep")
+    def test_cron_loop_completes_two_checks(self, mock_sleep, mock_run_check):
+        """Verifies the loop advances next_run after each check."""
+        call_count = 0
+
+        def shutdown_after_second_check():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                main_mod.shutdown_requested = True
+
+        mock_run_check.side_effect = shutdown_after_second_check
+
+        with patch.object(config_mod, "RUN_ON_STARTUP", False), \
+             patch.object(config_mod, "CRON_SCHEDULE", "* * * * *"), \
+             pytest.raises(SystemExit) as exc_info:
+            main_mod.main()
+
+        assert exc_info.value.code == 0
+        assert mock_run_check.call_count == 2

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,175 @@
+"""Unit tests for app.state — SQLite state persistence."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+import app.state as state
+from app.models import UpdateInfo
+
+
+def _make_update(**overrides) -> UpdateInfo:
+    defaults = dict(
+        container_name="web",
+        stack="mystack",
+        image="nginx",
+        current_version="1.0.0",
+        new_version="1.1.0",
+        update_type="minor",
+    )
+    defaults.update(overrides)
+    return UpdateInfo(**defaults)
+
+
+class TestInsert:
+    def test_insert_new_update(self):
+        u = _make_update()
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t)
+
+        assert len(result) == 1
+        assert result[0].container_name == "web"
+        assert result[0].status == "new"
+
+    def test_insert_sets_first_and_last_seen(self):
+        u = _make_update()
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t)
+        rows = state.get_active_updates()
+
+        assert len(rows) == 1
+        assert rows[0]["first_seen_at"] == t.isoformat()
+        assert rows[0]["last_seen_at"] == t.isoformat()
+        assert rows[0]["notified_at"] is None
+
+    def test_insert_multiple_updates(self):
+        u1 = _make_update(new_version="1.1.0", update_type="minor")
+        u2 = _make_update(new_version="2.0.0", update_type="major")
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        result = state.process_scan([u1, u2], scan_time=t)
+        new = [r for r in result if r.status == "new"]
+        assert len(new) == 2
+
+
+class TestUpsert:
+    def test_upsert_updates_last_seen(self):
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        result = state.process_scan([u], scan_time=t2)
+
+        # Second scan should return as known, not new
+        assert len(result) == 1
+        assert result[0].status == "known"
+
+        rows = state.get_active_updates()
+        assert rows[0]["first_seen_at"] == t1.isoformat()
+        assert rows[0]["last_seen_at"] == t2.isoformat()
+
+    def test_upsert_re_opens_resolved(self):
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        t3 = datetime(2026, 1, 3, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        result2 = state.process_scan([], scan_time=t2)
+
+        # Should be resolved
+        assert len(result2) == 1
+        assert result2[0].status == "resolved"
+        assert len(state.get_active_updates()) == 0
+
+        # Re-appear in scan — was seen before so it's "known"
+        result3 = state.process_scan([u], scan_time=t3)
+        active = [r for r in result3 if r.status != "resolved"]
+        assert len(active) == 1
+        assert active[0].status == "known"
+
+
+class TestResolve:
+    def test_resolve_absent_marks_missing(self):
+        u1 = _make_update(new_version="1.1.0", update_type="minor")
+        u2 = _make_update(new_version="2.0.0", update_type="major")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1, u2], scan_time=t1)
+        # Second scan only has u1 — u2 should be resolved
+        result = state.process_scan([u1], scan_time=t2)
+
+        known = [r for r in result if r.status == "known"]
+        resolved = [r for r in result if r.status == "resolved"]
+        assert len(known) == 1
+        assert known[0].new_version == "1.1.0"
+        assert len(resolved) == 1
+        assert resolved[0].new_version == "2.0.0"
+
+    def test_resolve_all_when_empty_scan(self):
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        result = state.process_scan([], scan_time=t2)
+
+        assert len(result) == 1
+        assert result[0].status == "resolved"
+        assert len(state.get_active_updates()) == 0
+
+
+class TestQueryByStatus:
+    def test_get_active_excludes_resolved(self):
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        state.process_scan([], scan_time=t2)
+
+        assert len(state.get_active_updates()) == 0
+
+    def test_process_scan_returns_all_statuses(self):
+        u1 = _make_update(new_version="1.1.0", update_type="minor")
+        u2 = _make_update(new_version="2.0.0", update_type="major")
+        u3 = _make_update(container_name="cache", image="redis",
+                          new_version="7.2.0", update_type="minor")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1, u2], scan_time=t1)
+        result = state.process_scan([u1, u3], scan_time=t2)
+
+        statuses = {r.status for r in result}
+        assert statuses == {"new", "known", "resolved"}
+
+
+class TestMarkNotified:
+    def test_mark_notified_sets_timestamp(self):
+        u = _make_update()
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t)
+        state.mark_notified(result, notified_time=t)
+
+        rows = state.get_active_updates()
+        assert rows[0]["notified_at"] == t.isoformat()
+
+    def test_mark_notified_idempotent(self):
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t1)
+        state.mark_notified(result, notified_time=t1)
+        state.mark_notified(result, notified_time=t2)
+
+        rows = state.get_active_updates()
+        # Should keep the first notified_at
+        assert rows[0]["notified_at"] == t1.isoformat()

--- a/tests/test_state_integration.py
+++ b/tests/test_state_integration.py
@@ -1,0 +1,89 @@
+"""Integration test: two consecutive scans produce correct state transitions."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+import app.state as state
+from app.models import UpdateInfo
+
+
+def test_two_consecutive_scans():
+    """Simulate two scans: first introduces updates, second resolves one and adds another."""
+    t1 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t2 = datetime(2026, 4, 1, 13, 0, 0, tzinfo=timezone.utc)
+
+    update_a = UpdateInfo(
+        container_name="web",
+        stack="mystack",
+        image="nginx",
+        current_version="1.0.0",
+        new_version="1.1.0",
+        update_type="minor",
+    )
+    update_b = UpdateInfo(
+        container_name="db",
+        stack="mystack",
+        image="postgres",
+        current_version="15.0",
+        new_version="15.1",
+        update_type="patch",
+    )
+    update_c = UpdateInfo(
+        container_name="cache",
+        stack="mystack",
+        image="redis",
+        current_version="7.0.0",
+        new_version="7.2.0",
+        update_type="minor",
+    )
+
+    # --- Scan 1: A and B are new ---
+    result1 = state.process_scan([update_a, update_b], scan_time=t1)
+
+    new1 = [r for r in result1 if r.status == "new"]
+    assert len(new1) == 2
+    assert len(result1) == 2  # no resolved yet
+
+    active = state.get_active_updates()
+    assert len(active) == 2
+    for row in active:
+        assert row["first_seen_at"] == t1.isoformat()
+        assert row["last_seen_at"] == t1.isoformat()
+        assert row["resolved_at"] is None
+        assert row["notified_at"] is None
+
+    # Mark as notified
+    state.mark_notified(result1, notified_time=t1)
+
+    # --- Scan 2: A still present, B gone, C is new ---
+    result2 = state.process_scan([update_a, update_c], scan_time=t2)
+
+    new2 = [r for r in result2 if r.status == "new"]
+    known2 = [r for r in result2 if r.status == "known"]
+    resolved2 = [r for r in result2 if r.status == "resolved"]
+
+    # C is new, A is known, B is resolved
+    assert len(new2) == 1
+    assert new2[0].container_name == "cache"
+    assert len(known2) == 1
+    assert known2[0].container_name == "web"
+    assert len(resolved2) == 1
+    assert resolved2[0].container_name == "db"
+
+    active = state.get_active_updates()
+    assert len(active) == 2
+    active_names = {r["container_name"] for r in active}
+    assert active_names == {"web", "cache"}
+
+    # Check A: known — first_seen < last_seen
+    row_a = next(r for r in active if r["container_name"] == "web")
+    assert row_a["first_seen_at"] == t1.isoformat()
+    assert row_a["last_seen_at"] == t2.isoformat()
+    assert row_a["notified_at"] == t1.isoformat()
+
+    # Check C: new — first_seen == last_seen == t2
+    row_c = next(r for r in active if r["container_name"] == "cache")
+    assert row_c["first_seen_at"] == t2.isoformat()
+    assert row_c["last_seen_at"] == t2.isoformat()
+    assert row_c["notified_at"] is None

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -16,6 +16,7 @@ def _make_update():
         current_version="1.0.0",
         new_version="1.1.0",
         update_type="minor",
+        status="new",
     )
 
 


### PR DESCRIPTION
- Add STATE_DB_PATH configuration to specify the database location.
- Create state management functions to process scans and manage update statuses.
- Update notification logic to categorize updates by status.
- Enhance models to include status tracking for updates.
- Modify tests to cover new state management functionality and ensure correct behavior.