### PR TITLE
Add API endpoint for last scan and enhance dashboard notifications

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -84,6 +84,12 @@ def create_app() -> Flask:
         _scan_trigger.set()
         return jsonify({"message": "Scan triggered"}), 202
 
+    @application.route("/api/last-scan")
+    def api_last_scan():
+        with _state_lock:
+            last_check = _state.get("last_check")
+        return jsonify({"last_check": last_check})
+
     return application
 
 

--- a/app/health.py
+++ b/app/health.py
@@ -30,9 +30,9 @@ def update_state(*, last_check: datetime | None = None, next_check: datetime | N
         if containers_monitored is not None:
             _state["containers_monitored"] = containers_monitored
         if warnings is not None:
-            _state["warnings"] = warnings
+            _state["warnings"] = list(warnings)
         if skipped_containers is not None:
-            _state["skipped_containers"] = skipped_containers
+            _state["skipped_containers"] = list(skipped_containers)
 
 
 def _build_response() -> tuple[int, dict]:

--- a/app/notifications/email.py
+++ b/app/notifications/email.py
@@ -214,8 +214,9 @@ def notify(
         _config.log.warning("SMTP not fully configured (SMTP_HOST, SMTP_FROM, SMTP_TO required) — skipping email notification.")
         return
 
-    total = len(updates)
-    subject = f"\U0001f433 Docker Update Monitor \u2013 {total} image update{'s' if total > 1 else ''}"
+    new, known, resolved = _split_by_status(updates)
+    total = len(_dedup(new)) + len(_dedup(known)) + len(_dedup(resolved))
+    subject = f"\U0001f433 Docker Update Monitor \u2013 {total} image update{'s' if total != 1 else ''}"
 
     msg = MIMEMultipart("alternative")
     msg["Subject"] = subject

--- a/app/registry/base.py
+++ b/app/registry/base.py
@@ -22,7 +22,8 @@ def detect_registry(image_name: str) -> str:
     if "/" not in image_name:
         return "dockerhub"
     # Two-part names like "linuxserver/sonarr" are DockerHub namespaced images
+    # but only if the first part has no dot AND no colon (port means it's a registry address)
     parts = image_name.split("/")
-    if len(parts) == 2 and "." not in parts[0]:
+    if len(parts) == 2 and "." not in parts[0] and ":" not in parts[0]:
         return "dockerhub"
     return "unknown"

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -176,6 +176,49 @@
             color: #64748b;
         }
 
+        .update-banner {
+            display: none;
+            position: fixed;
+            top: 1rem;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #1d4ed8;
+            color: #fff;
+            padding: 0.75rem 1.25rem;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, .2);
+            z-index: 1000;
+            font-size: 0.9rem;
+            display: none;
+            align-items: center;
+            gap: 0.75rem;
+            animation: slideDown 0.3s ease-out;
+        }
+
+        .update-banner.visible {
+            display: flex;
+        }
+
+        .update-banner button {
+            background: #fff;
+            color: #1d4ed8;
+            border: none;
+            padding: 0.4rem 0.8rem;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 600;
+            font-size: 0.85rem;
+        }
+
+        .update-banner button:hover {
+            background: #e0e7ff;
+        }
+
+        @keyframes slideDown {
+            from { opacity: 0; transform: translateX(-50%) translateY(-1rem); }
+            to { opacity: 1; transform: translateX(-50%) translateY(0); }
+        }
+
         .card--warnings .value {
             color: #d97706;
         }
@@ -239,6 +282,10 @@
 </head>
 
 <body>
+    <div class="update-banner" id="update-banner">
+        <span>&#x1f504; New scan results available</span>
+        <button onclick="location.reload()">Refresh</button>
+    </div>
     <div class="container">
         <h1>&#x1f433; Docker Update Monitor</h1>
 
@@ -439,7 +486,7 @@
                     scanBtn.textContent = 'Scanning...';
                     fetch('/api/scan', { method: 'POST' })
                         .then(function () {
-                            setTimeout(function () { location.reload(); }, 3000);
+                            scanBtn.textContent = 'Scan triggered';
                         })
                         .catch(function () {
                             scanBtn.disabled = false;
@@ -448,13 +495,28 @@
                 });
             }
 
-            // Poll for updates every 60 seconds
-            setInterval(function () {
-                fetch('/api/updates')
+            // --- Poll for new scan results ---
+            var lastCheck = '{{ last_check }}';
+            var banner = document.getElementById('update-banner');
+
+            function pollForScanUpdate() {
+                fetch('/api/last-scan')
                     .then(function (r) { return r.json(); })
-                    .then(function () { location.reload(); })
+                    .then(function (data) {
+                        var serverCheck = data.last_check || '';
+                        if (serverCheck && serverCheck !== lastCheck) {
+                            banner.classList.add('visible');
+                            // Re-enable scan button if it was disabled
+                            if (scanBtn) {
+                                scanBtn.disabled = false;
+                                scanBtn.textContent = 'Scan Now';
+                            }
+                        }
+                    })
                     .catch(function () { });
-            }, 60000);
+            }
+
+            setInterval(pollForScanUpdate, 10000);
         })();
     </script>
 </body>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -312,3 +312,41 @@ class TestSkippedContainersDisplay:
         resp = client.get("/")
         html = resp.data.decode()
         assert '<table class="skipped-table">' not in html
+
+
+class TestApiLastScanRoute:
+    """Tests for GET /api/last-scan"""
+
+    def test_returns_null_before_first_scan(self, client):
+        from app.health import _state, _state_lock
+        with _state_lock:
+            original = _state.get("last_check")
+            _state["last_check"] = None
+        resp = client.get("/api/last-scan")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data == {"last_check": None}
+        with _state_lock:
+            _state["last_check"] = original
+
+    def test_returns_last_check_timestamp(self, client):
+        from app.health import _state, _state_lock
+        with _state_lock:
+            original = _state.get("last_check")
+            _state["last_check"] = "2026-04-30T12:00:00Z"
+        resp = client.get("/api/last-scan")
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data == {"last_check": "2026-04-30T12:00:00Z"}
+        with _state_lock:
+            _state["last_check"] = original
+
+    def test_update_banner_in_dashboard_html(self, client):
+        from app.health import _state, _state_lock
+        from unittest.mock import patch as _p
+        with _p("app.dashboard.get_all_updates", return_value=[]):
+            resp = client.get("/")
+        html = resp.data.decode()
+        assert 'id="update-banner"' in html
+        assert "New scan results available" in html
+        assert "/api/last-scan" in html

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -67,6 +67,19 @@ class TestDetectRegistryUnknown:
         assert detect_registry("my.registry.local/app") == "unknown"
 
 
+class TestDetectRegistryLocalRegistry:
+    """Local registries with ports should not be mistaken for DockerHub."""
+
+    def test_localhost_with_port(self):
+        assert detect_registry("localhost:5000/image") == "unknown"
+
+    def test_hostname_with_port(self):
+        assert detect_registry("myhost:5000/myapp") == "unknown"
+
+    def test_ip_with_port(self):
+        assert detect_registry("192.168.1.1:5000/image") == "unknown"
+
+
 class TestDetectRegistryURL:
     """Images specified as full URLs (with scheme)."""
 

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -208,6 +208,31 @@ class TestEmailNotify:
         assert "text/plain" in raw_email
         assert "text/html" in raw_email
 
+    @patch("app.notifications.email.smtplib.SMTP")
+    def test_subject_count_uses_deduped_total(self, mock_smtp_cls):
+        """Subject count should match body count after dedup."""
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value = mock_server
+
+        updates = [
+            _make_update(container_name="app1", image="nginx", update_type="minor", status="known"),
+            _make_update(container_name="app2", image="nginx", update_type="minor", status="known"),
+            _make_update(container_name="app3", image="redis", update_type="patch", status="known"),
+        ]
+
+        with patch.object(config_mod, "SMTP_HOST", "smtp.example.com"), \
+             patch.object(config_mod, "SMTP_PORT", 587), \
+             patch.object(config_mod, "SMTP_FROM", "from@example.com"), \
+             patch.object(config_mod, "SMTP_TO", ["to@example.com"]), \
+             patch.object(config_mod, "SMTP_TLS", False), \
+             patch.object(config_mod, "SMTP_USERNAME", ""), \
+             patch.object(config_mod, "SMTP_PASSWORD", ""):
+            email_notify(updates)
+
+        raw_email = mock_server.sendmail.call_args[0][2]
+        # 3 raw updates, but nginx+minor deduplicates to 1, so total = 2
+        assert "2_image_updates" in raw_email  # Q-encoded subject
+
 
 class TestNotifyChannelsDispatch:
     """Tests for the channel dispatcher."""
@@ -478,3 +503,109 @@ class TestNotifyWithMismatchesAndWarnings:
             email_notify([], warnings=[_make_warning()])
 
         mock_server.sendmail.assert_called_once()
+
+
+class TestSubjectEdgeCases:
+    @patch("app.notifications.email.smtplib.SMTP")
+    def test_subject_singular_with_one_update(self, mock_smtp_cls):
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value = mock_server
+
+        with patch.object(config_mod, "SMTP_HOST", "smtp.example.com"), \
+             patch.object(config_mod, "SMTP_PORT", 587), \
+             patch.object(config_mod, "SMTP_FROM", "from@example.com"), \
+             patch.object(config_mod, "SMTP_TO", ["to@example.com"]), \
+             patch.object(config_mod, "SMTP_TLS", False), \
+             patch.object(config_mod, "SMTP_USERNAME", ""), \
+             patch.object(config_mod, "SMTP_PASSWORD", ""):
+            email_notify([_make_update()])
+
+        raw_email = mock_server.sendmail.call_args[0][2]
+        assert "1_image_update?=" in raw_email  # singular, Q-encoded
+
+    @patch("app.notifications.email.smtplib.SMTP")
+    def test_subject_zero_when_only_mismatches(self, mock_smtp_cls):
+        """When only mismatches/warnings are sent, subject says '0 image updates' (plural)."""
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value = mock_server
+
+        with patch.object(config_mod, "SMTP_HOST", "smtp.example.com"), \
+             patch.object(config_mod, "SMTP_PORT", 587), \
+             patch.object(config_mod, "SMTP_FROM", "from@example.com"), \
+             patch.object(config_mod, "SMTP_TO", ["to@example.com"]), \
+             patch.object(config_mod, "SMTP_TLS", False), \
+             patch.object(config_mod, "SMTP_USERNAME", ""), \
+             patch.object(config_mod, "SMTP_PASSWORD", ""):
+            email_notify([], mismatches=[_make_mismatch()])
+
+        raw_email = mock_server.sendmail.call_args[0][2]
+        assert "0_image_updates" in raw_email  # Q-encoded, plural for zero
+
+
+class TestBuildRowsEdgeCases:
+    def test_service_name_fallback_to_container_name(self):
+        html = _build_html([_make_update(service_name=None, container_name="my-container")])
+        # service_name is None, so container_name should appear in both Service and Container columns
+        assert "my-container" in html
+
+    def test_current_version_none_shows_dash(self):
+        html = _build_html([_make_update(current_version=None)])
+        assert "\u2014" in html  # em dash fallback
+
+    def test_unknown_update_type_uses_gray_color(self):
+        html = _build_html([_make_update(update_type="unknown")])
+        assert "#6b7280" in html  # gray fallback color
+
+    def test_plain_service_name_fallback(self):
+        text = _build_plain([_make_update(service_name=None, container_name="my-container")])
+        assert "my-container (my-container)" in text
+
+
+class TestBuildHtmlDedup:
+    def test_html_body_deduplicates_same_image_and_type(self):
+        updates = [
+            _make_update(container_name="app1", image="nginx", update_type="minor", new_version="1.1.0"),
+            _make_update(container_name="app2", image="nginx", update_type="minor", new_version="1.2.0"),
+            _make_update(container_name="app3", image="redis", update_type="patch", new_version="7.1.0"),
+        ]
+        html = _build_html(updates)
+        assert "(2)" in html  # "New updates (2)" — 2 after dedup, not 3
+        # Keeps highest version
+        assert "1.2.0" in html
+        assert "1.1.0" not in html
+
+    def test_plain_body_deduplicates_same_image_and_type(self):
+        updates = [
+            _make_update(container_name="app1", image="nginx", update_type="minor", new_version="1.1.0"),
+            _make_update(container_name="app2", image="nginx", update_type="minor", new_version="1.2.0"),
+            _make_update(container_name="app3", image="redis", update_type="patch", new_version="7.1.0"),
+        ]
+        text = _build_plain(updates)
+        assert "New updates (2)" in text
+        assert "1.2.0" in text
+        assert "1.1.0" not in text
+
+
+class TestBuildWarningsHtmlEdgeCases:
+    def test_warning_without_image_shows_dash(self):
+        html = _build_warnings_section_html([_make_warning(image=None)])
+        assert "\u2014" in html  # em dash fallback
+
+
+class TestSplitByStatusEdgeCases:
+    def test_unknown_status_is_silently_dropped(self):
+        updates = [
+            _make_update(status="new"),
+            _make_update(status="unknown_status"),
+        ]
+        new, known, resolved = _split_by_status(updates)
+        assert len(new) == 1
+        assert len(known) == 0
+        assert len(resolved) == 0
+
+
+class TestMismatchServiceNameFallback:
+    def test_html_uses_container_name_when_service_name_none(self):
+        m = _make_mismatch(service_name=None, container_name="my-container")
+        html = _build_mismatch_section_html([m])
+        assert "my-container" in html

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -67,6 +67,24 @@ class TestHealthResponse:
             assert health._state["last_check"] == "2026-04-28T03:00:00Z"
             assert health._state["containers_monitored"] == 5
 
+    def test_update_state_warnings_not_mutated_by_caller(self):
+        """Verify that modifying the list after update_state doesn't affect internal state."""
+        warnings = [{"container_name": "app", "message": "warn"}]
+        health.update_state(warnings=warnings)
+        # Mutate the original list
+        warnings.append({"container_name": "evil", "message": "injected"})
+
+        with health._state_lock:
+            # State should not have the injected entry
+            assert len(health._state["warnings"]) == 1
+
+    def test_update_state_stores_skipped_containers(self):
+        skipped = [{"container_name": "x", "stack": "s", "image": "img", "reason": "no label"}]
+        health.update_state(skipped_containers=skipped)
+
+        with health._state_lock:
+            assert health._state["skipped_containers"] == skipped
+
 
 class TestHealthEndpoint:
     """Integration tests hitting the actual HTTP server."""

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -155,3 +155,206 @@ class TestNotifyEmptyList:
             notify([])
 
         mock_session.post.assert_not_called()
+
+
+class TestNotifyPayloadStructure:
+    """Payload grouping, field removal, mismatches and warnings."""
+
+    @patch.object(http_mod, "http_session")
+    def test_payload_groups_by_status(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        updates = [
+            _make_update(container_name="a", status="new"),
+            _make_update(container_name="b", status="known"),
+            _make_update(container_name="c", status="resolved"),
+        ]
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify(updates)
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert "new" in payload
+        assert "known" in payload
+        assert "resolved" in payload
+        assert payload["new"][0]["container_name"] == "a"
+        assert payload["known"][0]["container_name"] == "b"
+        assert payload["resolved"][0]["container_name"] == "c"
+
+    @patch.object(http_mod, "http_session")
+    def test_payload_removes_status_field_from_entries(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify([_make_update()])
+
+        payload = mock_session.post.call_args[1]["json"]
+        for entry in payload["new"]:
+            assert "status" not in entry
+
+    @patch.object(http_mod, "http_session")
+    def test_payload_includes_mismatches(self, mock_session):
+        from app.models import RegexMismatch
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        mismatch = RegexMismatch(
+            container_name="app", service_name="app", stack="stack",
+            image="nginx", current_tag="latest", pattern=r"^\d+$",
+            reason="did not match",
+        )
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify([_make_update()], mismatches=[mismatch])
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert "regex_mismatches" in payload
+        assert payload["regex_mismatches"][0]["container_name"] == "app"
+
+    @patch.object(http_mod, "http_session")
+    def test_payload_includes_warnings(self, mock_session):
+        from app.models import ScanWarning
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        warning = ScanWarning(
+            container_name="app", image="nginx",
+            level="warning", message="fetch failed",
+        )
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify([_make_update()], warnings=[warning])
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert "warnings" in payload
+        assert payload["warnings"][0]["message"] == "fetch failed"
+
+    @patch.object(http_mod, "http_session")
+    def test_payload_omits_empty_status_groups(self, mock_session):
+        """If no 'known' updates, that key is absent from payload."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify([_make_update(status="new")])
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert "new" in payload
+        assert "known" not in payload
+        assert "resolved" not in payload
+
+
+class TestNotifyHttpErrors:
+    """HTTP errors and timeouts."""
+
+    @patch.object(http_mod, "http_session")
+    def test_raise_for_status_error_is_caught(self, mock_session, caplog):
+        import logging
+        from requests.exceptions import HTTPError
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = HTTPError("500 Server Error")
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""), \
+             caplog.at_level(logging.ERROR):
+            notify([_make_update()])  # should not raise
+
+        assert "Failed to notify" in caplog.text
+
+    @patch.object(http_mod, "http_session")
+    def test_timeout_error_is_caught(self, mock_session, caplog):
+        import logging
+        from requests.exceptions import Timeout
+
+        mock_session.post.side_effect = Timeout("Read timed out")
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""), \
+             caplog.at_level(logging.ERROR):
+            notify([_make_update()])  # should not raise
+
+        assert "Failed to notify" in caplog.text
+
+
+class TestNotifyMisconfiguredAuth:
+    """Edge cases in auth configuration."""
+
+    @patch.object(http_mod, "http_session")
+    def test_unknown_auth_type_logs_warning(self, mock_session, caplog):
+        import logging
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", "oauth2"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", "token"), \
+             caplog.at_level(logging.WARNING):
+            notify([_make_update()])
+
+        assert "Unknown NOTIFY_AUTH_TYPE" in caplog.text
+        # Should still POST without Authorization header
+        headers = mock_session.post.call_args[1]["headers"]
+        assert "Authorization" not in headers
+
+    @patch.object(http_mod, "http_session")
+    def test_mismatches_only_triggers_post(self, mock_session):
+        """If only mismatches are present (no updates), webhook still fires."""
+        from app.models import RegexMismatch
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        mismatch = RegexMismatch(
+            container_name="app", service_name="app", stack="stack",
+            image="nginx", current_tag="latest", pattern=r"^\d+$",
+            reason="did not match",
+        )
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            notify([], mismatches=[mismatch])
+
+        mock_session.post.assert_called_once()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -245,3 +245,115 @@ class TestFetchAllTags:
     def test_unknown_registry_returns_empty(self):
         tags = fetch_all_tags("quay.io/org/image", None, "")
         assert tags == []
+
+    @patch("app.registry._fetch_dockerhub_tags", return_value=["1.0.0"])
+    def test_passes_current_tag_to_dockerhub(self, mock_fetch):
+        fetch_all_tags("nginx", "token", "", "1.0.0")
+        mock_fetch.assert_called_once_with("nginx", "token", "1.0.0")
+
+    @patch("app.registry._fetch_ghcr_tags", return_value=["v1.0.0"])
+    def test_passes_current_tag_to_ghcr(self, mock_fetch):
+        fetch_all_tags("ghcr.io/owner/repo", None, "gh_token", "v1.0.0")
+        mock_fetch.assert_called_once_with("ghcr.io/owner/repo", "gh_token", "v1.0.0")
+
+
+class TestDockerhubTokenEdgeCases:
+    """Edge cases for get_dockerhub_token."""
+
+    @patch.object(http_mod, "http_session")
+    def test_response_missing_token_field(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"message": "ok"}  # no token key
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        result = get_dockerhub_token("user", "pass")
+        assert result is None
+
+    @patch.object(http_mod, "http_session")
+    def test_successful_token_returned(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"token": "abc123"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        result = get_dockerhub_token("user", "pass")
+        assert result == "abc123"
+
+
+class TestFetchDockerhubAnonymous:
+    """DockerHub fetch without credentials."""
+
+    @patch.object(http_mod, "http_session")
+    def test_anonymous_fetch_no_auth_header(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": [{"name": "latest"}], "next": None}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.get.return_value = mock_resp
+
+        tags = _fetch_dockerhub_tags("nginx", None)
+        assert tags == ["latest"]
+        # Verify no Authorization header
+        call_kwargs = mock_session.get.call_args
+        headers = call_kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert "Authorization" not in headers
+
+
+class TestFetchGhcrEdgeCases:
+    """GHCR edge cases."""
+
+    @patch.object(http_mod, "http_session")
+    def test_both_endpoints_404_returns_empty(self, mock_session):
+        """When both org and user endpoints return 404, return empty list."""
+        resp_404 = MagicMock()
+        resp_404.status_code = 404
+        resp_404.raise_for_status = MagicMock(side_effect=requests.HTTPError("404"))
+
+        mock_session.get.side_effect = [resp_404, resp_404]
+
+        tags = _fetch_ghcr_tags("ghcr.io/owner/repo", "gh_token")
+        assert tags == []
+
+    @patch.object(http_mod, "http_session")
+    def test_multi_level_namespace(self, mock_session):
+        """ghcr.io/org/group/image should construct correct API URL."""
+        resp_ok = MagicMock()
+        resp_ok.status_code = 200
+        resp_ok.json.return_value = [
+            {"metadata": {"container": {"tags": ["v1.0.0"]}}},
+        ]
+        resp_ok.raise_for_status = MagicMock()
+
+        resp_empty = MagicMock()
+        resp_empty.status_code = 200
+        resp_empty.json.return_value = []
+        resp_empty.raise_for_status = MagicMock()
+
+        mock_session.get.side_effect = [resp_ok, resp_empty]
+
+        tags = _fetch_ghcr_tags("ghcr.io/org/group/image", "gh_token")
+        assert tags == ["v1.0.0"]
+        url = mock_session.get.call_args_list[0][0][0]
+        assert "group/image" in url or "group%2Fimage" in url
+
+    @patch.object(http_mod, "http_session")
+    def test_version_without_tags_key_is_skipped(self, mock_session):
+        """API response with missing metadata is handled gracefully."""
+        resp_ok = MagicMock()
+        resp_ok.status_code = 200
+        resp_ok.json.return_value = [
+            {"metadata": {"container": {"tags": ["v1.0.0"]}}},
+            {"metadata": {}},  # no 'container' key
+            {"metadata": {"container": {}}},  # no 'tags' key
+        ]
+        resp_ok.raise_for_status = MagicMock()
+
+        resp_empty = MagicMock()
+        resp_empty.status_code = 200
+        resp_empty.json.return_value = []
+        resp_empty.raise_for_status = MagicMock()
+
+        mock_session.get.side_effect = [resp_ok, resp_empty]
+
+        tags = _fetch_ghcr_tags("ghcr.io/owner/repo", "gh_token")
+        assert tags == ["v1.0.0"]  # only the one with valid tags

--- a/tests/test_run_check.py
+++ b/tests/test_run_check.py
@@ -193,6 +193,165 @@ class TestRunCheckContainerProcessing:
 
         assert "GitHub token present" in caplog.text
 
+    @patch("app.scanner.notify")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_empty_containers_list(self, mock_docker, mock_token, mock_notify, caplog):
+        """Empty container list results in no updates and notify still called."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = []
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.INFO):
+            run_check()
+
+        assert "Running containers: 0" in caplog.text
+        mock_notify.assert_called_once()
+        updates = mock_notify.call_args[0][0]
+        assert updates == []
+
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan", return_value=[])
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_mark_notified_not_called_when_no_categorized(self, mock_docker, mock_token,
+                                                          mock_fetch, mock_scan, mock_mark):
+        """mark_notified() should NOT be called when process_scan returns empty."""
+        container = _make_container(
+            "app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        mock_mark.assert_not_called()
+
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_mark_notified_called_when_categorized_nonempty(self, mock_docker, mock_token,
+                                                            mock_fetch, mock_scan, mock_mark):
+        """mark_notified() should be called when process_scan returns updates."""
+        from app.models import UpdateInfo
+        categorized = [UpdateInfo(
+            container_name="app", service_name="app", stack="stack",
+            image="nginx", current_version="1.0.0", new_version="2.0.0",
+            update_type="major", status="new",
+        )]
+        mock_scan.return_value = categorized
+
+        container = _make_container(
+            "app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        mock_mark.assert_called_once()
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "1.1.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_stack_fallback_to_standalone(self, mock_docker, mock_token, mock_fetch, caplog):
+        """Container without stack label or compose project defaults to 'standalone'."""
+        import logging
+
+        container = _make_container(
+            "solo-app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.INFO):
+            run_check()
+
+        assert "stack=standalone" in caplog.text
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "1.1.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_cache_different_versions_same_image(self, mock_docker, mock_token, mock_fetch):
+        """Two containers running different versions of same image should fetch tags independently."""
+        container1 = _make_container(
+            "app1", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        container2 = _make_container(
+            "app2", "nginx:1.1.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container1, container2]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # fetch_all_tags should be called twice with different current_tag
+        assert mock_fetch.call_count == 2
+        calls = mock_fetch.call_args_list
+        assert calls[0][0][3] == "1.0.0"  # current_tag for first
+        assert calls[1][0][3] == "1.1.0"  # current_tag for second
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "1.1.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_cache_same_version_fetches_once(self, mock_docker, mock_token, mock_fetch):
+        """Two containers with same image and version should fetch only once."""
+        container1 = _make_container(
+            "app1", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        container2 = _make_container(
+            "app2", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container1, container2]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # Only one fetch due to cache hit
+        assert mock_fetch.call_count == 1
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_invalid_regex_skips_and_warns(self, mock_docker, mock_token, mock_fetch, caplog):
+        """Container with invalid regex pattern should be skipped with a warning."""
+        import logging
+
+        container = _make_container(
+            "bad-regex", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+["},  # invalid regex
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.WARNING):
+            run_check()
+
+        assert "Invalid tag-regex" in caplog.text
+        mock_fetch.assert_not_called()
+
 
 class TestMainEdgeCases:
     """Edge cases in main()."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -243,3 +243,38 @@ class TestGetAllUpdates:
         all_updates = state.get_all_updates()
         statuses = {u["status"] for u in all_updates}
         assert statuses == {"known", "resolved"}
+
+    def test_resolved_status_takes_precedence_over_notified(self):
+        """An update that was notified and then resolved should show as 'resolved'."""
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t1)
+        state.mark_notified(result, notified_time=t1)
+        # Resolve the update
+        state.process_scan([], scan_time=t2)
+
+        all_updates = state.get_all_updates()
+        assert len(all_updates) == 1
+        assert all_updates[0]["status"] == "resolved"
+
+
+class TestProcessScanEdgeCases:
+    def test_empty_container_name(self):
+        """Update with empty container_name is stored and retrieved."""
+        u = _make_update(container_name="")
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t)
+        assert len(result) == 1
+        assert result[0].container_name == ""
+
+    def test_empty_image(self):
+        """Update with empty image is stored and retrieved."""
+        u = _make_update(image="")
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        result = state.process_scan([u], scan_time=t)
+        assert len(result) == 1
+        assert result[0].image == ""


### PR DESCRIPTION
- Implemented `/api/last-scan` endpoint to retrieve the last scan timestamp.
- Added an update banner in the dashboard to notify users of new scan results.
- Updated JavaScript polling mechanism to check for scan updates every 10 seconds.
- Modified email notification subject to reflect deduplicated update counts.
- Adjusted health state management to ensure warnings and skipped containers are stored correctly.
- Enhanced unit tests for new features and edge cases.