### PR TITLE
Add per-container cooldown feature and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ services:
       # Optional — overrides auto-detected Compose project name
       # docker-update-monitor.stack: "media"
 
+      # Optional — per-container cooldown, overrides the global UPDATE_COOLDOWN
+      # docker-update-monitor.update-cooldown: "3d"
+
   nginx:
     image: nginx:1.25.3
     labels:
@@ -128,18 +131,19 @@ update-level finding for one container:
 
 ### General
 
-| Variable             | Default          | Description                                                         |
-| -------------------- | ---------------- | ------------------------------------------------------------------- |
-| `NOTIFY_CHANNELS`    | `webhook`        | Comma-separated list of notification channels: `webhook`, `email`   |
-| `DOCKERHUB_USERNAME` | _(empty)_        | Docker Hub username                                                 |
-| `DOCKERHUB_PASSWORD` | _(empty)_        | Docker Hub password or PAT                                          |
-| `GITHUB_TOKEN`       | _(empty)_        | GitHub PAT with `read:packages` scope — required for ghcr.io images |
-| `CRON_SCHEDULE`      | `0 * * * *`      | Cron expression for check schedule (standard 5-field cron)          |
-| `RUN_ON_STARTUP`     | `true`           | Run an update check immediately on startup                          |
-| `DRY_RUN`            | `false`          | Log only, no notifications sent                                     |
-| `LABEL_PREFIX`       | `update-monitor` | Label namespace                                                     |
-| `LOG_LEVEL`          | `INFO`           | `DEBUG` / `INFO` / `WARNING` / `ERROR`                              |
-| `WEB_PORT`           | `8080`           | Port for the web dashboard and health endpoint                      |
+| Variable             | Default          | Description                                                                                                                                                                                                |
+| -------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NOTIFY_CHANNELS`    | `webhook`        | Comma-separated list of notification channels: `webhook`, `email`                                                                                                                                          |
+| `DOCKERHUB_USERNAME` | _(empty)_        | Docker Hub username                                                                                                                                                                                        |
+| `DOCKERHUB_PASSWORD` | _(empty)_        | Docker Hub password or PAT                                                                                                                                                                                 |
+| `GITHUB_TOKEN`       | _(empty)_        | GitHub PAT with `read:packages` scope — required for ghcr.io images                                                                                                                                        |
+| `CRON_SCHEDULE`      | `0 * * * *`      | Cron expression for check schedule (standard 5-field cron)                                                                                                                                                 |
+| `RUN_ON_STARTUP`     | `true`           | Run an update check immediately on startup                                                                                                                                                                 |
+| `DRY_RUN`            | `false`          | Log only, no notifications sent                                                                                                                                                                            |
+| `LABEL_PREFIX`       | `update-monitor` | Label namespace                                                                                                                                                                                            |
+| `UPDATE_COOLDOWN`    | `0`              | Global cooldown before notifying about a new update. Accepted formats: `0` (no cooldown), `12h`, `3d`, `2w`, `1m`. Can be overridden per container with the `docker-update-monitor.update-cooldown` label. |
+| `LOG_LEVEL`          | `INFO`           | `DEBUG` / `INFO` / `WARNING` / `ERROR`                                                                                                                                                                     |
+| `WEB_PORT`           | `8080`           | Port for the web dashboard and health endpoint                                                                                                                                                             |
 
 ### Webhook channel
 

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,8 @@ SMTP_TLS          = os.environ.get("SMTP_TLS", "true").lower() == "true"
 WEB_PORT          = int(os.environ.get("WEB_PORT", "8080"))
 DASHBOARD_DATETIME_FORMAT = os.environ.get("DASHBOARD_DATETIME_FORMAT", "%d/%m/%Y %H:%M")
 
+UPDATE_COOLDOWN   = os.environ.get("UPDATE_COOLDOWN", "0")
+
 logging.basicConfig(
     level=getattr(logging, LOG_LEVEL, logging.INFO),
     format="%(asctime)s  %(levelname)-8s  %(message)s",

--- a/app/cooldown.py
+++ b/app/cooldown.py
@@ -1,0 +1,48 @@
+"""Utilities for parsing and applying update cooldown periods."""
+
+import re
+from datetime import timedelta
+
+
+def parse_cooldown(value: str) -> timedelta:
+    """Parse a cooldown string into a :class:`timedelta`.
+
+    Accepted formats:
+    - ``"0"`` or ``""`` — no cooldown
+    - ``"<n>h"`` — *n* hours
+    - ``"<n>d"`` — *n* days
+    - ``"<n>w"`` — *n* weeks
+    - ``"<n>m"`` — *n* months (≈ 30 days each)
+
+    Examples::
+
+        parse_cooldown("0")   → timedelta(0)
+        parse_cooldown("12h") → timedelta(hours=12)
+        parse_cooldown("3d")  → timedelta(days=3)
+        parse_cooldown("2w")  → timedelta(weeks=2)
+        parse_cooldown("1m")  → timedelta(days=30)
+
+    Raises :class:`ValueError` for unrecognised formats.
+    """
+    value = value.strip()
+    if not value or value == "0":
+        return timedelta(0)
+
+    m = re.fullmatch(r"(\d+)([hdwm])", value)
+    if not m:
+        raise ValueError(
+            f"Invalid cooldown format '{value}'. "
+            "Expected '0', or a positive integer followed by h/d/w/m (e.g. '12h', '3d', '2w', '1m')."
+        )
+
+    amount = int(m.group(1))
+    unit = m.group(2)
+
+    if unit == "h":
+        return timedelta(hours=amount)
+    if unit == "d":
+        return timedelta(days=amount)
+    if unit == "w":
+        return timedelta(weeks=amount)
+    # unit == "m"
+    return timedelta(days=amount * 30)

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,7 @@ class UpdateInfo:
     new_version: str
     update_type: str        # "patch" | "minor" | "major"
     status: str = ""        # "new" | "known" | "resolved"
+    first_seen_at: str | None = None
 
 
 @dataclass

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -1,10 +1,11 @@
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import docker
 from docker.errors import DockerException
 
 import app.config as _config
+from app.cooldown import parse_cooldown
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
 from app.registry import fetch_all_tags
 from app.registry.dockerhub import get_dockerhub_token
@@ -43,6 +44,7 @@ def run_check() -> None:
     all_warnings: list[ScanWarning] = []
     skipped_containers: list[dict] = []
     monitored_versions: dict[tuple[str, str], tuple[str, str]] = {}
+    container_cooldowns: dict[str, object] = {}  # container_name → timedelta
     monitored_count = 0
 
     for container in containers:
@@ -71,6 +73,16 @@ def run_check() -> None:
             continue
 
         monitored_count += 1
+
+        # Parse per-container cooldown label; fall back to global config
+        cooldown_label = labels.get(f"{_config.LABEL_PREFIX}.update-cooldown", _config.UPDATE_COOLDOWN)
+        try:
+            container_cooldowns[container.name] = parse_cooldown(cooldown_label)
+        except ValueError:
+            _config.log.warning(
+                f"  [{container.name}] Invalid update-cooldown value '{cooldown_label}' — using no cooldown"
+            )
+            container_cooldowns[container.name] = parse_cooldown("0")
 
         try:
             re.compile(pattern)
@@ -199,10 +211,28 @@ def run_check() -> None:
     resolved_count = sum(1 for u in categorized if u.status == "resolved")
     _config.log.info(f"  New: {new_count}  |  Known: {known_count}  |  Resolved: {resolved_count}")
 
+    # Apply cooldown — suppress new/known updates that haven't matured yet
+    global_cooldown = parse_cooldown(_config.UPDATE_COOLDOWN)
+    actionable: list[UpdateInfo] = []
+    for u in categorized:
+        if u.status == "resolved":
+            actionable.append(u)
+            continue
+        cooldown = container_cooldowns.get(u.container_name, global_cooldown)
+        if cooldown and u.first_seen_at:
+            first_seen = datetime.fromisoformat(u.first_seen_at)
+            if scan_time - first_seen < cooldown:
+                _config.log.info(
+                    f"  [{u.container_name}] {u.current_version} → {u.new_version} "
+                    f"in cooldown ({cooldown}), skipping notification"
+                )
+                continue
+        actionable.append(u)
+
     # Notify with all categorized updates (grouped by status in payload)
-    notify(categorized, mismatches=all_mismatches, warnings=all_warnings)
-    if categorized:
-        mark_notified(categorized, scan_time)
+    notify(actionable, mismatches=all_mismatches, warnings=all_warnings)
+    if actionable:
+        mark_notified(actionable, scan_time)
 
     # Update health endpoint state
     warnings_data = [

--- a/app/state.py
+++ b/app/state.py
@@ -164,6 +164,7 @@ def process_scan(
                 new_version=row["new_version"],
                 update_type=row["update_type"],
                 status=status,
+                first_seen_at=row["first_seen_at"],
             ))
 
         for row in resolved_rows:
@@ -176,6 +177,7 @@ def process_scan(
                 new_version=row["new_version"],
                 update_type=row["update_type"],
                 status="resolved",
+                first_seen_at=row["first_seen_at"],
             ))
 
         return result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       # Set to "true" to log updates without POSTing — useful for testing
       DRY_RUN: "false"
 
+      # Cooldown period before notifying about a newly detected update.
+      # Accepted formats: "0" (no cooldown, default), "12h", "3d", "2w", "1m".
+      # Can be overridden per container with the docker-update-monitor.update-cooldown label.
+      # UPDATE_COOLDOWN: "0"
+
       # Label namespace (default: docker-update-monitor)
       # LABEL_PREFIX: "docker-update-monitor"
       # Only docker containers with docker-update-monitor.tag-regex are monitored

--- a/tests/test_parse_cooldown.py
+++ b/tests/test_parse_cooldown.py
@@ -1,0 +1,83 @@
+"""Unit tests for parse_cooldown() — format parsing and edge cases."""
+
+from datetime import timedelta
+
+import pytest
+
+from app.cooldown import parse_cooldown
+
+
+class TestParseCooldownZero:
+    def test_zero_string(self):
+        assert parse_cooldown("0") == timedelta(0)
+
+    def test_empty_string(self):
+        assert parse_cooldown("") == timedelta(0)
+
+    def test_whitespace_only(self):
+        assert parse_cooldown("   ") == timedelta(0)
+
+
+class TestParseCooldownHours:
+    def test_one_hour(self):
+        assert parse_cooldown("1h") == timedelta(hours=1)
+
+    def test_twelve_hours(self):
+        assert parse_cooldown("12h") == timedelta(hours=12)
+
+    def test_large_hours(self):
+        assert parse_cooldown("48h") == timedelta(hours=48)
+
+
+class TestParseCooldownDays:
+    def test_one_day(self):
+        assert parse_cooldown("1d") == timedelta(days=1)
+
+    def test_three_days(self):
+        assert parse_cooldown("3d") == timedelta(days=3)
+
+    def test_seven_days(self):
+        assert parse_cooldown("7d") == timedelta(days=7)
+
+
+class TestParseCooldownWeeks:
+    def test_one_week(self):
+        assert parse_cooldown("1w") == timedelta(weeks=1)
+
+    def test_two_weeks(self):
+        assert parse_cooldown("2w") == timedelta(weeks=2)
+
+
+class TestParseCooldownMonths:
+    def test_one_month(self):
+        assert parse_cooldown("1m") == timedelta(days=30)
+
+    def test_three_months(self):
+        assert parse_cooldown("3m") == timedelta(days=90)
+
+
+class TestParseCooldownWhitespace:
+    def test_leading_and_trailing_whitespace(self):
+        assert parse_cooldown("  12h  ") == timedelta(hours=12)
+
+
+class TestParseCooldownInvalid:
+    def test_unknown_unit_raises(self):
+        with pytest.raises(ValueError, match="Invalid cooldown format"):
+            parse_cooldown("5x")
+
+    def test_missing_unit_raises(self):
+        with pytest.raises(ValueError, match="Invalid cooldown format"):
+            parse_cooldown("42")
+
+    def test_text_only_raises(self):
+        with pytest.raises(ValueError, match="Invalid cooldown format"):
+            parse_cooldown("daily")
+
+    def test_float_raises(self):
+        with pytest.raises(ValueError, match="Invalid cooldown format"):
+            parse_cooldown("1.5h")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="Invalid cooldown format"):
+            parse_cooldown("-3d")

--- a/tests/test_run_check.py
+++ b/tests/test_run_check.py
@@ -1,10 +1,12 @@
 """Unit tests for run_check() — Docker connection, container processing, and main() edge cases."""
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 import pytest
 
 from app import config as config_mod
 from app import main as main_mod
+from app.models import UpdateInfo
 from app.scanner import run_check
 
 
@@ -351,6 +353,209 @@ class TestRunCheckContainerProcessing:
 
         assert "Invalid tag-regex" in caplog.text
         mock_fetch.assert_not_called()
+
+
+class TestRunCheckCooldown:
+    """Cooldown suppression behaviour in run_check()."""
+
+    _CONTAINER_NAME = "app"
+    _PATTERN = r"^(\d+)\.(\d+)\.(\d+)$"
+
+    def _make_update(self, first_seen_at: str) -> UpdateInfo:
+        return UpdateInfo(
+            container_name=self._CONTAINER_NAME,
+            service_name=self._CONTAINER_NAME,
+            stack="stack",
+            image="nginx",
+            current_version="1.0.0",
+            new_version="2.0.0",
+            update_type="major",
+            status="new",
+            first_seen_at=first_seen_at,
+        )
+
+    def _mock_docker(self, mock_docker, labels=None):
+        if labels is None:
+            labels = {f"docker-update-monitor.tag-regex": self._PATTERN}
+        container = _make_container(self._CONTAINER_NAME, "nginx:1.0.0", labels)
+        client = MagicMock()
+        mock_docker.from_env.return_value = client
+        client.containers.list.return_value = [container]
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_update_within_cooldown_not_notified(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """An update first seen moments ago is suppressed when a cooldown is set."""
+        fixed_now = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+        # first_seen_at is 1 hour ago, cooldown is 12h → still within cooldown
+        first_seen = (fixed_now - timedelta(hours=1)).isoformat()
+        mock_scan.return_value = [self._make_update(first_seen)]
+
+        self._mock_docker(mock_docker)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "12h"), \
+             patch("app.scanner.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            run_check()
+
+        mock_notify.assert_called_once()
+        notified_updates = mock_notify.call_args[0][0]
+        assert notified_updates == []
+        mock_mark.assert_not_called()
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_update_past_cooldown_is_notified(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """An update first seen long enough ago passes through the cooldown filter."""
+        fixed_now = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+        # first_seen_at is 13 hours ago, cooldown is 12h → past cooldown
+        first_seen = (fixed_now - timedelta(hours=13)).isoformat()
+        mock_scan.return_value = [self._make_update(first_seen)]
+
+        self._mock_docker(mock_docker)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "12h"), \
+             patch("app.scanner.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            run_check()
+
+        mock_notify.assert_called_once()
+        notified_updates = mock_notify.call_args[0][0]
+        assert len(notified_updates) == 1
+        assert notified_updates[0].new_version == "2.0.0"
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_per_container_label_overrides_global_cooldown(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """Per-container label cooldown takes precedence over global UPDATE_COOLDOWN."""
+        fixed_now = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+        # first_seen_at is 6 hours ago; global=0 (no cooldown), label=12h → suppressed
+        first_seen = (fixed_now - timedelta(hours=6)).isoformat()
+        mock_scan.return_value = [self._make_update(first_seen)]
+
+        labels = {
+            "docker-update-monitor.tag-regex": self._PATTERN,
+            "docker-update-monitor.update-cooldown": "12h",
+        }
+        self._mock_docker(mock_docker, labels=labels)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "0"), \
+             patch("app.scanner.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            run_check()
+
+        notified_updates = mock_notify.call_args[0][0]
+        assert notified_updates == []
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_per_container_label_zero_bypasses_global_cooldown(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """Per-container label '0' disables cooldown even when global cooldown is set."""
+        fixed_now = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+        # first_seen_at is 1 hour ago; global=12h, label=0 → not suppressed
+        first_seen = (fixed_now - timedelta(hours=1)).isoformat()
+        mock_scan.return_value = [self._make_update(first_seen)]
+
+        labels = {
+            "docker-update-monitor.tag-regex": self._PATTERN,
+            "docker-update-monitor.update-cooldown": "0",
+        }
+        self._mock_docker(mock_docker, labels=labels)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "12h"), \
+             patch("app.scanner.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            run_check()
+
+        notified_updates = mock_notify.call_args[0][0]
+        assert len(notified_updates) == 1
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_invalid_cooldown_label_warns_and_uses_zero(
+        self, mock_docker, mock_token, mock_fetch, caplog
+    ):
+        """An invalid per-container cooldown label logs a warning and uses no cooldown."""
+        import logging
+
+        labels = {
+            "docker-update-monitor.tag-regex": self._PATTERN,
+            "docker-update-monitor.update-cooldown": "bad-value",
+        }
+        self._mock_docker(mock_docker, labels=labels)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "0"), \
+             caplog.at_level(logging.WARNING):
+            run_check()
+
+        assert "Invalid update-cooldown value" in caplog.text
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_resolved_updates_always_pass_through(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """Resolved updates are never blocked by the cooldown filter."""
+        fixed_now = datetime(2026, 1, 10, 12, 0, 0, tzinfo=timezone.utc)
+        # first_seen_at is 1 minute ago — well within any cooldown
+        first_seen = (fixed_now - timedelta(minutes=1)).isoformat()
+        resolved = UpdateInfo(
+            container_name=self._CONTAINER_NAME,
+            service_name=self._CONTAINER_NAME,
+            stack="stack",
+            image="nginx",
+            current_version="2.0.0",
+            new_version="2.0.0",
+            update_type="major",
+            status="resolved",
+            first_seen_at=first_seen,
+        )
+        mock_scan.return_value = [resolved]
+
+        self._mock_docker(mock_docker)
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "UPDATE_COOLDOWN", "12h"), \
+             patch("app.scanner.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.fromisoformat.side_effect = datetime.fromisoformat
+            run_check()
+
+        notified_updates = mock_notify.call_args[0][0]
+        assert len(notified_updates) == 1
+        assert notified_updates[0].status == "resolved"
 
 
 class TestMainEdgeCases:


### PR DESCRIPTION
- Introduced a per-container cooldown period that overrides the global cooldown setting.
- Updated README and docker-compose.yml to reflect new configuration options.
- Enhanced the run_check function to respect cooldowns for notifications.
- Added utility functions for parsing cooldown strings.
- Implemented unit tests to validate cooldown functionality and edge cases.