### PR TITLE
Fix digest containers showing raw sha256 instead of git-hash tag as n…

### DIFF
--- a/app/scanner.py
+++ b/app/scanner.py
@@ -1,6 +1,8 @@
 import re
 from datetime import datetime, timedelta, timezone
 
+_GIT_HASH_RE = re.compile(r"sha-[a-f0-9]{7,}")
+
 import docker
 from docker.errors import DockerException
 
@@ -21,15 +23,16 @@ def _resolve_digest_to_tag(
     target_digest: str,
     all_tags: list[str],
     pattern: str,
+    current_tag: str = "",
 ) -> str | None:
-    """Find which versioned tag (matching *pattern*) shares the same digest.
+    """Find which tag shares the same digest as target_digest.
 
-    Iterates through tags that match the regex pattern and fetches their digest.
-    Returns the first tag whose digest matches *target_digest*, or None.
+    First tries tags matching the version pattern (fast path for semver images).
+    Falls back to non-pattern, non-current tags when no versioned tag matches —
+    covers git-hash tags (e.g. sha-675e77e) used by GHCR and Docker Hub.
+    The pattern defines what is "versioned"; everything else is treated as rolling.
     """
-    import re as _re
-    matching_tags = [t for t in all_tags if _re.fullmatch(pattern, t)]
-
+    matching_tags = [t for t in all_tags if re.fullmatch(pattern, t)]
     for tag in matching_tags:
         tag_digest = fetch_digest(
             image_name, tag,
@@ -38,6 +41,23 @@ def _resolve_digest_to_tag(
         )
         if tag_digest == target_digest:
             return tag
+
+    # Fallback: check non-pattern, non-current tags (rolling tags like sha-XXXXXXX).
+    # Prefer git-hash style tags first; cap at 20 to limit extra API calls.
+    fallback = [
+        t for t in all_tags
+        if t != current_tag and not re.fullmatch(pattern, t)
+    ]
+    fallback.sort(key=lambda t: (0 if _GIT_HASH_RE.fullmatch(t) else 1, t))
+    for tag in fallback[:20]:
+        tag_digest = fetch_digest(
+            image_name, tag,
+            _config.DOCKERHUB_USER, _config.DOCKERHUB_PASS,
+            _config.GITHUB_TOKEN,
+        )
+        if tag_digest == target_digest:
+            return tag
+
     return None
 
 
@@ -207,6 +227,7 @@ def run_check() -> None:
                 # Try to find which versioned tag matches the new digest
                 resolved_version = _resolve_digest_to_tag(
                     image_name, current_digest, all_tags, pattern,
+                    current_tag=current_tag,
                 )
 
                 if resolved_version:

--- a/tests/test_digest_detection.py
+++ b/tests/test_digest_detection.py
@@ -134,6 +134,94 @@ class TestDigestVersionResolution:
         )
         assert result is None
 
+    @patch("app.scanner.fetch_digest")
+    def test_resolve_digest_finds_git_hash_tag(self, mock_fetch_digest):
+        def digest_side_effect(image, tag, *args, **kwargs):
+            if tag == "sha-675e77e":
+                return "sha256:newdigest111"
+            return "sha256:other"
+
+        mock_fetch_digest.side_effect = digest_side_effect
+
+        result = _resolve_digest_to_tag(
+            "ghcr.io/myorg/myimage",
+            "sha256:newdigest111",
+            ["edge", "sha-675e77e"],
+            r"^(\d+)\.(\d+)\.(\d+)$",
+            current_tag="edge",
+        )
+        assert result == "sha-675e77e"
+
+    @patch("app.scanner.fetch_digest")
+    def test_resolve_digest_excludes_current_tag_from_fallback(self, mock_fetch_digest):
+        mock_fetch_digest.return_value = "sha256:target"
+
+        result = _resolve_digest_to_tag(
+            "myimage",
+            "sha256:target",
+            ["edge"],
+            r"^(\d+)\.(\d+)\.(\d+)$",
+            current_tag="edge",
+        )
+        assert result is None
+
+    @patch("app.scanner.fetch_digest")
+    def test_resolve_digest_prefers_git_hash_over_other_rolling_tags(self, mock_fetch_digest):
+        def digest_side_effect(image, tag, *args, **kwargs):
+            if tag in ("latest", "sha-abcdef1"):
+                return "sha256:target"
+            return "sha256:other"
+
+        mock_fetch_digest.side_effect = digest_side_effect
+
+        result = _resolve_digest_to_tag(
+            "myimage",
+            "sha256:target",
+            ["edge", "latest", "sha-abcdef1"],
+            r"^(\d+)\.(\d+)\.(\d+)$",
+            current_tag="edge",
+        )
+        assert result == "sha-abcdef1"
+
+
+class TestDigestGitHashTagIntegration:
+    """End-to-end: a rolling-tag container shows the git-hash tag as new version."""
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.fetch_all_tags", return_value=["edge", "sha-675e77e"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_digest_change_shows_git_hash_tag(
+        self, mock_docker, mock_token, mock_fetch_tags, mock_fetch_digest, mock_notify
+    ):
+        container = _make_container(
+            "myapp", "ghcr.io/myorg/myimage:edge",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        store_digest("ghcr.io/myorg/myimage", "edge", "sha256:olddigest000000000000")
+
+        def digest_side_effect(image, tag, *args, **kwargs):
+            if tag in ("edge", "sha-675e77e"):
+                return "sha256:newdigest111111111111"
+            return "sha256:other"
+
+        mock_fetch_digest.side_effect = digest_side_effect
+
+        with patch.object(config_mod, "GITHUB_TOKEN", "ghtoken"):
+            run_check()
+
+        assert mock_notify.called
+        updates_arg = mock_notify.call_args[0][0]
+        digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+        assert len(digest_updates) == 1
+        assert digest_updates[0].new_version == "sha-675e77e"
+        assert digest_updates[0].current_version == "edge"
+
 
 class TestDigestFallbackToShortDigest:
     """If no versioned tag matches, show the short digest."""


### PR DESCRIPTION
…ew version

When a rolling-tag container (e.g. edge) detects a digest change, _resolve_digest_to_tag now falls back to non-pattern, non-current tags after the semver pass fails. Git-hash style tags (sha-XXXXXXX) are sorted first, so sha-675e77e is preferred over other co-tags.

Closes #100