### PR TITLE
Fix digest updates accumulating in overview when rolling tag digest changes

### DIFF
--- a/app/migrations.py
+++ b/app/migrations.py
@@ -3,6 +3,17 @@
 import sqlite3
 
 
+def _unique_index_has_new_version(conn: sqlite3.Connection) -> bool:
+    """Return True if the updates table still has its UNIQUE index on new_version."""
+    for row in conn.execute("PRAGMA index_list(updates)").fetchall():
+        if not row[2]:  # not a unique index
+            continue
+        cols = {r[2] for r in conn.execute(f"PRAGMA index_info({row[1]})").fetchall()}
+        if "new_version" in cols:
+            return True
+    return False
+
+
 def run_migrations(conn: sqlite3.Connection) -> None:
     """Apply all pending migrations to an existing database."""
     existing = {row[1] for row in conn.execute("PRAGMA table_info(updates)").fetchall()}
@@ -25,3 +36,42 @@ def run_migrations(conn: sqlite3.Connection) -> None:
                 PRIMARY KEY (image, tag)
             )
         """)
+
+    # Change UNIQUE constraint from (container_name, image, new_version, update_type) to
+    # (container_name, image, current_version, update_type) so that repeated digest changes
+    # for the same rolling tag replace the single row rather than accumulating entries.
+    if _unique_index_has_new_version(conn):
+        conn.execute("""\
+            CREATE TABLE updates_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                container_name TEXT NOT NULL,
+                service_name TEXT NOT NULL DEFAULT '',
+                image TEXT NOT NULL,
+                current_version TEXT NOT NULL,
+                new_version TEXT NOT NULL,
+                update_type TEXT NOT NULL,
+                stack TEXT NOT NULL DEFAULT '',
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                notified_at TEXT,
+                resolved_at TEXT,
+                UNIQUE(container_name, image, current_version, update_type)
+            )
+        """)
+        # Keep the most recently seen row per new unique key to discard stale duplicates.
+        conn.execute("""\
+            INSERT INTO updates_new (id, container_name, service_name, image, current_version,
+                                     new_version, update_type, stack, first_seen_at, last_seen_at,
+                                     notified_at, resolved_at)
+            SELECT id, container_name, service_name, image, current_version,
+                   new_version, update_type, stack, first_seen_at, last_seen_at,
+                   notified_at, resolved_at
+            FROM updates
+            WHERE id IN (
+                SELECT MAX(id)
+                FROM updates
+                GROUP BY container_name, image, current_version, update_type
+            )
+        """)
+        conn.execute("DROP TABLE updates")
+        conn.execute("ALTER TABLE updates_new RENAME TO updates")

--- a/app/state.py
+++ b/app/state.py
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS updates (
     last_seen_at TEXT NOT NULL,
     notified_at TEXT,
     resolved_at TEXT,
-    UNIQUE(container_name, image, new_version, update_type)
+    UNIQUE(container_name, image, current_version, update_type)
 );
 """
 
@@ -93,19 +93,21 @@ def process_scan(
                 """INSERT INTO updates (container_name, service_name, image, current_version, new_version,
                                         update_type, stack, first_seen_at, last_seen_at, resolved_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-                   ON CONFLICT(container_name, image, new_version, update_type) DO UPDATE SET
+                   ON CONFLICT(container_name, image, current_version, update_type) DO UPDATE SET
+                       new_version = excluded.new_version,
                        last_seen_at = excluded.last_seen_at,
-                       current_version = excluded.current_version,
                        service_name = excluded.service_name,
                        stack = excluded.stack,
-                       resolved_at = NULL""",
+                       resolved_at = NULL,
+                       notified_at = CASE WHEN excluded.new_version != updates.new_version THEN NULL ELSE updates.notified_at END,
+                       first_seen_at = CASE WHEN excluded.new_version != updates.new_version THEN excluded.first_seen_at ELSE updates.first_seen_at END""",
                 (u.container_name, u.service_name, u.image, u.current_version, u.new_version,
                  u.update_type, u.stack, ts, ts),
             )
 
         # --- resolve or delete absent entries ---
         current_keys = {
-            (u.container_name, u.image, u.new_version, u.update_type)
+            (u.container_name, u.image, u.current_version, u.update_type)
             for u in updates
         }
 
@@ -117,7 +119,7 @@ def process_scan(
         resolved_ids: list[int] = []
 
         for row in active_rows:
-            key = (row["container_name"], row["image"], row["new_version"], row["update_type"])
+            key = (row["container_name"], row["image"], row["current_version"], row["update_type"])
             if key in current_keys:
                 continue  # still detected, already upserted
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -44,17 +44,61 @@ class TestMigrations:
         conn.close()
 
     def test_idempotent_on_current_schema(self):
-        """Running migrations on a DB that already has the columns does nothing."""
+        """Running migrations on a DB that already has all migrations applied does nothing."""
         conn = sqlite3.connect(":memory:")
         conn.execute(_OLD_SCHEMA)
         conn.execute("ALTER TABLE updates ADD COLUMN service_name TEXT NOT NULL DEFAULT ''")
         conn.execute("ALTER TABLE updates ADD COLUMN stack TEXT NOT NULL DEFAULT ''")
         conn.commit()
-        # Should not raise
+        # First run applies the constraint migration
+        run_migrations(conn)
+        # Second run is a no-op
         run_migrations(conn)
         cols = {row[1] for row in conn.execute("PRAGMA table_info(updates)").fetchall()}
         assert "service_name" in cols
         assert "stack" in cols
+        conn.close()
+
+    def test_migrates_unique_constraint_to_current_version(self):
+        """Migration replaces UNIQUE(new_version) with UNIQUE(current_version)."""
+        conn = self._make_old_db()
+        run_migrations(conn)
+
+        unique_cols: set[str] = set()
+        for idx_row in conn.execute("PRAGMA index_list(updates)").fetchall():
+            if not idx_row[2]:
+                continue
+            for col_row in conn.execute(f"PRAGMA index_info({idx_row[1]})").fetchall():
+                unique_cols.add(col_row[2])
+
+        assert "current_version" in unique_cols
+        assert "new_version" not in unique_cols
+        conn.close()
+
+    def test_migration_deduplicates_digest_rows(self):
+        """Migration keeps only the most recent row when two rows share the same
+        (container_name, image, current_version, update_type) after the constraint change."""
+        conn = self._make_old_db()
+        # Add service_name and stack before inserting data (as prior migrations would)
+        conn.execute("ALTER TABLE updates ADD COLUMN service_name TEXT NOT NULL DEFAULT ''")
+        conn.execute("ALTER TABLE updates ADD COLUMN stack TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            """INSERT INTO updates (container_name, service_name, image, current_version,
+                                    new_version, update_type, stack, first_seen_at, last_seen_at)
+               VALUES ('app', 'app', 'myimage', 'dev', 'sha-aaaaaaa', 'digest', '', 't1', 't1')"""
+        )
+        conn.execute(
+            """INSERT INTO updates (container_name, service_name, image, current_version,
+                                    new_version, update_type, stack, first_seen_at, last_seen_at)
+               VALUES ('app', 'app', 'myimage', 'dev', 'sha-bbbbbbb', 'digest', '', 't2', 't2')"""
+        )
+        conn.commit()
+
+        run_migrations(conn)
+
+        rows = conn.execute("SELECT new_version FROM updates").fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "sha-bbbbbbb"
         conn.close()
 
     def test_insert_works_after_migration(self):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -346,6 +346,106 @@ class TestGetAllUpdates:
         assert all_updates[0]["status"] == "resolved"
 
 
+class TestDigestDeduplication:
+    def _make_digest_update(self, **overrides) -> UpdateInfo:
+        defaults = dict(
+            container_name="app",
+            service_name="app",
+            stack="mystack",
+            image="ghcr.io/example/app",
+            current_version="dev",
+            new_version="sha-aaaaaa",
+            update_type="digest",
+        )
+        defaults.update(overrides)
+        return UpdateInfo(**defaults)
+
+    def test_second_digest_replaces_first(self):
+        """A second digest change replaces the first entry rather than accumulating."""
+        u1 = self._make_digest_update(new_version="sha-aaaaaa")
+        u2 = self._make_digest_update(new_version="sha-bbbbbb")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1], scan_time=t1)
+        state.process_scan([u2], scan_time=t2)
+
+        active = state.get_active_updates()
+        assert len(active) == 1
+        assert active[0]["new_version"] == "sha-bbbbbb"
+        assert active[0]["current_version"] == "dev"
+
+    def test_second_digest_is_new_status(self):
+        """A new digest hash is reported as 'new' even though the tag was already known."""
+        u1 = self._make_digest_update(new_version="sha-aaaaaa")
+        u2 = self._make_digest_update(new_version="sha-bbbbbb")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1], scan_time=t1)
+        result = state.process_scan([u2], scan_time=t2)
+
+        new_entries = [r for r in result if r.status == "new"]
+        assert len(new_entries) == 1
+        assert new_entries[0].new_version == "sha-bbbbbb"
+
+    def test_multiple_digest_changes_stay_single_entry(self):
+        """Three successive digest changes still produce only one row."""
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        t3 = datetime(2026, 1, 3, tzinfo=timezone.utc)
+
+        state.process_scan([self._make_digest_update(new_version="sha-aaaaaa")], scan_time=t1)
+        state.process_scan([self._make_digest_update(new_version="sha-bbbbbb")], scan_time=t2)
+        state.process_scan([self._make_digest_update(new_version="sha-cccccc")], scan_time=t3)
+
+        active = state.get_active_updates()
+        assert len(active) == 1
+        assert active[0]["new_version"] == "sha-cccccc"
+
+    def test_same_digest_re_detected_stays_known(self):
+        """When the same digest hash is re-detected the status remains 'known'."""
+        u = self._make_digest_update(new_version="sha-aaaaaa")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        result = state.process_scan([u], scan_time=t2)
+
+        assert len(result) == 1
+        assert result[0].status == "known"
+
+    def test_digest_change_resets_notified_at(self):
+        """A new digest hash resets notified_at so a fresh notification is sent."""
+        u1 = self._make_digest_update(new_version="sha-aaaaaa")
+        u2 = self._make_digest_update(new_version="sha-bbbbbb")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        result1 = state.process_scan([u1], scan_time=t1)
+        state.mark_notified(result1, notified_time=t1)
+        state.process_scan([u2], scan_time=t2)
+
+        active = state.get_active_updates()
+        assert len(active) == 1
+        assert active[0]["notified_at"] is None
+
+    def test_get_all_updates_shows_only_latest_digest(self):
+        """get_all_updates never returns more than one digest entry per container+tag."""
+        u1 = self._make_digest_update(new_version="sha-aaaaaa")
+        u2 = self._make_digest_update(new_version="sha-bbbbbb")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1], scan_time=t1)
+        state.process_scan([u2], scan_time=t2)
+
+        all_updates = state.get_all_updates()
+        digest_entries = [u for u in all_updates if u["update_type"] == "digest"]
+        assert len(digest_entries) == 1
+        assert digest_entries[0]["new_version"] == "sha-bbbbbb"
+
+
 class TestProcessScanEdgeCases:
     def test_empty_container_name(self):
         """Update with empty container_name is stored and retrieved."""


### PR DESCRIPTION
## Summary

- Changes the `updates` table UNIQUE constraint from `(container_name, image, new_version, update_type)` to `(container_name, image, current_version, update_type)` so repeated digest changes for the same rolling tag replace the single row in-place instead of inserting new accumulating rows
- Adds a database migration that recreates the table with the new constraint, deduplicating stale rows in existing installs (keeps the most recently seen entry per key)
- Resets `notified_at` and `first_seen_at` on the upserted row only when `new_version` actually changes, so unchanged digests stay `known` and don't trigger re-notifications

Closes #110

## Test plan

- [x] `TestDigestDeduplication::test_second_digest_replaces_first` — single row after two digest changes
- [x] `TestDigestDeduplication::test_second_digest_is_new_status` — new digest reports as `new`
- [x] `TestDigestDeduplication::test_multiple_digest_changes_stay_single_entry` — three changes → one row
- [x] `TestDigestDeduplication::test_same_digest_re_detected_stays_known` — unchanged digest stays `known`
- [x] `TestDigestDeduplication::test_digest_change_resets_notified_at` — new digest clears `notified_at`
- [x] `TestDigestDeduplication::test_get_all_updates_shows_only_latest_digest` — overview shows only latest
- [x] `TestMigrations::test_migrates_unique_constraint_to_current_version` — migration changes index columns
- [x] `TestMigrations::test_migration_deduplicates_digest_rows` — migration collapses stale duplicates
- [x] Full suite: `396 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)