### PR TITLE
Add Telegram notification channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 
 # Docker socket GID (find with: stat -c '%g' /var/run/docker.sock)
 DOCKER_GID=999
+
+# Telegram notification channel (optional)
+# TELEGRAM_BOT_TOKEN=123456789:ABCDefgh...
+# TELEGRAM_CHAT_ID=-1001234567890

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data-debug/
 .vscode/
 CLAUDE.md
 .claude/
+memory/

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ update-level finding for one container:
 
 | Variable             | Default          | Description                                                                                                                                                                                                |
 | -------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NOTIFY_CHANNELS`    | `webhook`        | Comma-separated list of notification channels: `webhook`, `email`                                                                                                                                          |
+| `NOTIFY_CHANNELS`    | `webhook`        | Comma-separated list of notification channels: `webhook`, `email`, `telegram`                                                                                                                              |
 | `DOCKERHUB_USERNAME` | _(empty)_        | Docker Hub username                                                                                                                                                                                        |
 | `DOCKERHUB_PASSWORD` | _(empty)_        | Docker Hub password or PAT                                                                                                                                                                                 |
 | `GITHUB_TOKEN`       | _(empty)_        | GitHub PAT with `read:packages` scope — required for ghcr.io images                                                                                                                                        |
@@ -182,6 +182,22 @@ update-level finding for one container:
 > **Note:** If `NOTIFY_CHANNELS` includes `email` but `SMTP_HOST`, `SMTP_FROM`,
 > or `SMTP_TO` are not set, the email channel logs a warning and is skipped —
 > the application does not crash.
+
+### Telegram channel
+
+| Variable              | Default   | Description                                                   |
+| --------------------- | --------- | ------------------------------------------------------------- |
+| `TELEGRAM_BOT_TOKEN`  | _(empty)_ | Bot token from [@BotFather](https://t.me/BotFather) (required for Telegram) |
+| `TELEGRAM_CHAT_ID`    | _(empty)_ | Target chat or channel ID (required for Telegram)             |
+
+To set up a Telegram bot:
+1. Message [@BotFather](https://t.me/BotFather) and run `/newbot` to get a token.
+2. Add the bot to your group/channel, or start a direct chat.
+3. Retrieve the chat ID (e.g. via `https://api.telegram.org/bot<TOKEN>/getUpdates`).
+
+> **Note:** If `NOTIFY_CHANNELS` includes `telegram` but `TELEGRAM_BOT_TOKEN`
+> or `TELEGRAM_CHAT_ID` are not set, the Telegram channel logs an error and is
+> skipped — the application does not crash.
 
 > **Note:** The `docker-compose.yml` in this repo sets `CRON_SCHEDULE` to
 > `0 3 * * 7` (every Sunday at 03:00), overriding the code default of
@@ -336,5 +352,6 @@ tests/
 ├── test_http_session.py        # HTTP session/retry config
 ├── test_regex_validation.py    # Invalid regex handling
 ├── test_graceful_shutdown.py   # SIGTERM/SIGINT handling
-└── test_run_on_startup.py      # RUN_ON_STARTUP behavior
+├── test_run_on_startup.py      # RUN_ON_STARTUP behavior
+└── test_notifications_telegram.py  # Telegram notification tests
 ```

--- a/app/config.py
+++ b/app/config.py
@@ -23,6 +23,9 @@ SMTP_FROM         = os.environ.get("SMTP_FROM", "")
 SMTP_TO           = [addr.strip() for addr in os.environ.get("SMTP_TO", "").split(",") if addr.strip()]
 SMTP_TLS          = os.environ.get("SMTP_TLS", "true").lower() == "true"
 
+TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+TELEGRAM_CHAT_ID   = os.environ.get("TELEGRAM_CHAT_ID", "")
+
 WEB_PORT          = int(os.environ.get("WEB_PORT", "8080"))
 DASHBOARD_DATETIME_FORMAT = os.environ.get("DASHBOARD_DATETIME_FORMAT", "%d/%m/%Y %H:%M")
 TZ                = os.environ.get("TZ", "")

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -2,6 +2,7 @@ import app.config as _config
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
 from app.notifications.webhook import notify as webhook_notify
 from app.notifications.email import notify as email_notify
+from app.notifications.telegram import notify as telegram_notify
 
 
 def dispatch(
@@ -19,5 +20,7 @@ def dispatch(
             webhook_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
         elif channel == "email":
             email_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
+        elif channel == "telegram":
+            telegram_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
         else:
             _config.log.warning(f"Unknown notification channel '{channel}' — skipping")

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -1,0 +1,143 @@
+import re
+
+import app.config as _config
+import app.http as _http
+from app.models import UpdateInfo, RegexMismatch, ScanWarning
+
+_TELEGRAM_API = "https://api.telegram.org/bot{token}/sendMessage"
+_MAX_MSG_LEN = 4096
+
+# All MarkdownV2 special characters that must be escaped in regular text
+_SPECIAL_TEXT = re.compile(r'([_*\[\]()~`>#+\-=|{}.!\\])')
+
+
+def _esc(text: str) -> str:
+    """Escape special chars for MarkdownV2 regular text."""
+    return _SPECIAL_TEXT.sub(r'\\\1', str(text))
+
+
+def _esc_code(text: str) -> str:
+    """Escape for MarkdownV2 code entity — only ` and \\ need escaping."""
+    return str(text).replace('\\', '\\\\').replace('`', '\\`')
+
+
+def _build_lines(
+    updates: list[UpdateInfo],
+    mismatches: list[RegexMismatch],
+    warnings: list[ScanWarning],
+) -> list[str]:
+    lines = ["*\U0001f433 Docker Updates Available*", ""]
+
+    new = [u for u in updates if u.status == "new"]
+    known = [u for u in updates if u.status == "known"]
+    resolved = [u for u in updates if u.status == "resolved"]
+
+    for emoji, title, group in [
+        ("\U0001f195", "New", new),
+        ("\U0001f504", "Known", known),
+        ("✅", "Resolved", resolved),
+    ]:
+        if not group:
+            continue
+        lines.append(f"{emoji} *{_esc(title)} \\({len(group)}\\)*")
+        for u in sorted(group, key=lambda x: (x.stack or "", x.image or "")):
+            service = _esc(u.service_name or u.container_name)
+            stack = _esc(u.stack)
+            current = _esc_code(u.current_version or "—")
+            new_ver = _esc_code(u.new_version)
+            update_type = _esc(u.update_type)
+            lines.append(f"• \\[{stack}\\] {service}: `{current}` → `{new_ver}` \\({update_type}\\)")
+        lines.append("")
+
+    if mismatches:
+        lines.append(f"⚠️ *Regex mismatches \\({len(mismatches)}\\)*")
+        for m in mismatches:
+            service = _esc(m.service_name or m.container_name)
+            stack = _esc(m.stack)
+            image = _esc(m.image)
+            tag = _esc_code(m.current_tag)
+            pattern = _esc_code(m.pattern)
+            lines.append(f"• \\[{stack}\\] {service} \\({image}:`{tag}`\\) pattern: `{pattern}`")
+        lines.append("")
+
+    if warnings:
+        lines.append(f"\U0001f6a8 *Warnings \\({len(warnings)}\\)*")
+        for w in warnings:
+            container = _esc(w.container_name)
+            level = _esc(w.level.upper())
+            message = _esc(w.message)
+            lines.append(f"• \\[{level}\\] {container}: {message}")
+        lines.append("")
+
+    return lines
+
+
+def _chunk_messages(lines: list[str]) -> list[str]:
+    """Split lines into message chunks that fit within Telegram's 4096-char limit."""
+    chunks: list[str] = []
+    current_parts: list[str] = []
+    current_len = 0
+
+    for line in lines:
+        line_len = len(line) + 1  # +1 for newline
+        if current_parts and current_len + line_len > _MAX_MSG_LEN:
+            chunks.append("\n".join(current_parts))
+            current_parts = []
+            current_len = 0
+        current_parts.append(line)
+        current_len += line_len
+
+    if current_parts:
+        chunks.append("\n".join(current_parts))
+
+    return chunks
+
+
+def _send_message(token: str, chat_id: str, text: str) -> bool:
+    url = _TELEGRAM_API.format(token=token)
+    try:
+        resp = _http.http_session.post(
+            url,
+            json={"chat_id": chat_id, "parse_mode": "MarkdownV2", "text": text},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return True
+    except Exception as exc:
+        _config.log.error(f"Failed to send Telegram message: {exc}")
+        return False
+
+
+def notify(
+    updates: list[UpdateInfo],
+    *,
+    mismatches: list[RegexMismatch] | None = None,
+    warnings: list[ScanWarning] | None = None,
+) -> bool:
+    if not updates and not mismatches and not warnings:
+        return True
+
+    if not _config.TELEGRAM_BOT_TOKEN or not _config.TELEGRAM_CHAT_ID:
+        _config.log.error(
+            "Telegram not configured: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required."
+        )
+        return False
+
+    lines = _build_lines(updates, mismatches or [], warnings or [])
+
+    if _config.DRY_RUN:
+        _config.log.info("DRY_RUN — would send Telegram message:\n" + "\n".join(lines))
+        return True
+
+    chunks = _chunk_messages(lines)
+    success = True
+    for chunk in chunks:
+        if not _send_message(_config.TELEGRAM_BOT_TOKEN, _config.TELEGRAM_CHAT_ID, chunk):
+            success = False
+
+    if success:
+        _config.log.info(
+            f"Telegram notification sent ({len(chunks)} message(s), {len(updates)} update(s))"
+        )
+
+    return success

--- a/app/notifications/telegram.py
+++ b/app/notifications/telegram.py
@@ -43,10 +43,11 @@ def _build_lines(
         for u in sorted(group, key=lambda x: (x.stack or "", x.image or "")):
             service = _esc(u.service_name or u.container_name)
             stack = _esc(u.stack)
+            image = _esc(u.image or "")
             current = _esc_code(u.current_version or "—")
             new_ver = _esc_code(u.new_version)
             update_type = _esc(u.update_type)
-            lines.append(f"• \\[{stack}\\] {service}: `{current}` → `{new_ver}` \\({update_type}\\)")
+            lines.append(f"• \\[{stack}\\] {service} \\({image}\\): `{current}` → `{new_ver}` \\({update_type}\\)")
         lines.append("")
 
     if mismatches:
@@ -74,6 +75,8 @@ def _build_lines(
 
 def _chunk_messages(lines: list[str]) -> list[str]:
     """Split lines into message chunks that fit within Telegram's 4096-char limit."""
+    if not lines:
+        return [""]
     chunks: list[str] = []
     current_parts: list[str] = []
     current_len = 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: unless-stopped
 
     environment:
-      # Notification channels: comma-separated list of "webhook", "email"
+      # Notification channels: comma-separated list of "webhook", "email", "telegram"
       # Default: webhook (backward compatible)
       NOTIFY_CHANNELS: "${NOTIFY_CHANNELS:-webhook}"
 
@@ -33,6 +33,11 @@ services:
       SMTP_FROM: "${SMTP_FROM}"
       SMTP_TO: "${SMTP_TO}"
       SMTP_TLS: "${SMTP_TLS:-true}"
+
+      # --- Telegram channel ---
+      # Required (if using telegram): TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN}"
+      TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID}"
 
       # Cron schedule for checks (default: every hour on the hour)
       # Standard 5-field cron: minute hour day month weekday

--- a/tests/test_notifications_telegram.py
+++ b/tests/test_notifications_telegram.py
@@ -387,7 +387,7 @@ class TestNotify:
                 image=f"img-{i}",
                 status="new",
             )
-            for i in range(60)
+            for i in range(90)
         ]
 
         with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \

--- a/tests/test_notifications_telegram.py
+++ b/tests/test_notifications_telegram.py
@@ -1,0 +1,460 @@
+"""Unit tests for the Telegram notification channel."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.config as config_mod
+from app.models import UpdateInfo, RegexMismatch, ScanWarning
+from app.notifications.telegram import (
+    notify,
+    _esc,
+    _esc_code,
+    _build_lines,
+    _chunk_messages,
+    _send_message,
+)
+from app.notifications import dispatch
+
+
+def _make_update(**kwargs):
+    defaults = dict(
+        container_name="test-app",
+        service_name="app",
+        stack="mystack",
+        image="nginx",
+        current_version="1.25",
+        new_version="1.27",
+        update_type="minor",
+        status="new",
+    )
+    defaults.update(kwargs)
+    return UpdateInfo(**defaults)
+
+
+def _make_mismatch(**kwargs):
+    defaults = dict(
+        container_name="test-app",
+        service_name="app",
+        stack="mystack",
+        image="nginx",
+        current_tag="latest",
+        pattern=r"^\d+\.\d+\.\d+$",
+        reason="did not match current tag",
+    )
+    defaults.update(kwargs)
+    return RegexMismatch(**defaults)
+
+
+def _make_warning(**kwargs):
+    defaults = dict(
+        container_name="test-app",
+        image="nginx",
+        level="warning",
+        message="Could not fetch tags",
+    )
+    defaults.update(kwargs)
+    return ScanWarning(**defaults)
+
+
+class TestEscapeText:
+    def test_escapes_dot(self):
+        assert _esc("1.25") == r"1\.25"
+
+    def test_escapes_parens(self):
+        assert _esc("(minor)") == r"\(minor\)"
+
+    def test_escapes_brackets(self):
+        assert _esc("[stack]") == r"\[stack\]"
+
+    def test_escapes_underscore(self):
+        assert _esc("my_stack") == r"my\_stack"
+
+    def test_escapes_asterisk(self):
+        assert _esc("a*b") == r"a\*b"
+
+    def test_escapes_backslash(self):
+        assert _esc("a\\b") == r"a\\b"
+
+    def test_escapes_hyphen(self):
+        assert _esc("my-stack") == r"my\-stack"
+
+    def test_plain_text_unchanged(self):
+        assert _esc("nginx") == "nginx"
+
+    def test_empty_string(self):
+        assert _esc("") == ""
+
+
+class TestEscapeCode:
+    def test_does_not_escape_dot(self):
+        assert _esc_code("1.25") == "1.25"
+
+    def test_escapes_backtick(self):
+        assert _esc_code("a`b") == "a\\`b"
+
+    def test_escapes_backslash(self):
+        assert _esc_code("a\\b") == "a\\\\b"
+
+    def test_plain_text_unchanged(self):
+        assert _esc_code("1.25.3") == "1.25.3"
+
+
+class TestBuildLines:
+    def test_header_present(self):
+        lines = _build_lines([_make_update()], [], [])
+        assert lines[0] == "*\U0001f433 Docker Updates Available*"
+
+    def test_new_update_included(self):
+        lines = _build_lines([_make_update(status="new")], [], [])
+        text = "\n".join(lines)
+        assert "New" in text
+        assert "nginx" in text
+        assert "1.25" in text  # unescaped in code context
+        assert "1.27" in text
+
+    def test_known_update_included(self):
+        lines = _build_lines([_make_update(status="known")], [], [])
+        text = "\n".join(lines)
+        assert "Known" in text
+
+    def test_resolved_update_included(self):
+        lines = _build_lines([_make_update(status="resolved")], [], [])
+        text = "\n".join(lines)
+        assert "Resolved" in text
+
+    def test_empty_status_groups_omitted(self):
+        lines = _build_lines([_make_update(status="new")], [], [])
+        text = "\n".join(lines)
+        assert "Known" not in text
+        assert "Resolved" not in text
+
+    def test_mismatches_included(self):
+        lines = _build_lines([], [_make_mismatch()], [])
+        text = "\n".join(lines)
+        assert "Regex mismatches" in text
+        assert "mystack" in text
+
+    def test_warnings_included(self):
+        lines = _build_lines([], [], [_make_warning()])
+        text = "\n".join(lines)
+        assert "Warnings" in text
+        assert "Could not fetch tags" in text
+
+    def test_update_sorted_by_stack_then_image(self):
+        updates = [
+            _make_update(stack="z-stack", image="redis", status="new"),
+            _make_update(stack="a-stack", image="nginx", status="new"),
+        ]
+        lines = _build_lines(updates, [], [])
+        text = "\n".join(lines)
+        a_pos = text.index("a\\-stack")
+        z_pos = text.index("z\\-stack")
+        assert a_pos < z_pos
+
+    def test_special_chars_in_stack_escaped(self):
+        lines = _build_lines([_make_update(stack="my.stack")], [], [])
+        text = "\n".join(lines)
+        assert r"my\.stack" in text
+
+    def test_service_name_fallback_to_container(self):
+        lines = _build_lines([_make_update(service_name=None, container_name="my-container")], [], [])
+        text = "\n".join(lines)
+        assert "my\\-container" in text
+
+    def test_current_version_none_uses_em_dash(self):
+        lines = _build_lines([_make_update(current_version=None)], [], [])
+        text = "\n".join(lines)
+        assert "—" in text
+
+    def test_count_in_section_header(self):
+        updates = [_make_update(status="new"), _make_update(status="new", image="redis")]
+        lines = _build_lines(updates, [], [])
+        text = "\n".join(lines)
+        assert r"\(2\)" in text
+
+
+class TestChunkMessages:
+    def test_short_message_is_single_chunk(self):
+        lines = ["line1", "line2", "line3"]
+        chunks = _chunk_messages(lines)
+        assert len(chunks) == 1
+        assert "line1" in chunks[0]
+        assert "line3" in chunks[0]
+
+    def test_long_message_splits_into_multiple_chunks(self):
+        # Create lines that total >4096 chars
+        lines = ["x" * 100] * 50  # 50 * 101 chars = 5050 chars
+        chunks = _chunk_messages(lines)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk) <= 4096
+
+    def test_empty_lines_single_empty_chunk(self):
+        chunks = _chunk_messages([])
+        assert chunks == [""]
+
+    def test_each_chunk_within_limit(self):
+        lines = ["a" * 200] * 25
+        chunks = _chunk_messages(lines)
+        for chunk in chunks:
+            assert len(chunk) <= 4096
+
+
+class TestSendMessage:
+    def test_returns_true_on_success(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            result = _send_message("tok123", "-100123", "hello")
+
+        assert result is True
+        mock_http_session.post.assert_called_once()
+        call_kwargs = mock_http_session.post.call_args
+        assert "tok123" in call_kwargs[0][0]
+        assert call_kwargs[1]["json"]["chat_id"] == "-100123"
+        assert call_kwargs[1]["json"]["parse_mode"] == "MarkdownV2"
+
+    def test_returns_false_and_logs_on_http_error(self, mock_http_session, caplog):
+        mock_http_session.post.side_effect = Exception("network error")
+
+        with caplog.at_level(logging.ERROR):
+            result = _send_message("tok", "chat", "text")
+
+        assert result is False
+        assert "Failed to send Telegram message" in caplog.text
+
+    def test_returns_false_on_bad_status(self, mock_http_session, caplog):
+        from requests import HTTPError
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = HTTPError("400 Bad Request")
+        mock_http_session.post.return_value = mock_resp
+
+        with caplog.at_level(logging.ERROR):
+            result = _send_message("tok", "chat", "text")
+
+        assert result is False
+        assert "Failed to send Telegram message" in caplog.text
+
+
+class TestNotify:
+    def test_empty_updates_returns_true_without_http(self, mock_http_session):
+        result = notify([])
+        assert result is True
+        mock_http_session.post.assert_not_called()
+
+    def test_missing_token_logs_error_and_returns_false(self, mock_http_session, caplog):
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", ""), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"), \
+             caplog.at_level(logging.ERROR):
+            result = notify([_make_update()])
+
+        assert result is False
+        assert "TELEGRAM_BOT_TOKEN" in caplog.text
+        mock_http_session.post.assert_not_called()
+
+    def test_missing_chat_id_logs_error_and_returns_false(self, mock_http_session, caplog):
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", ""), \
+             caplog.at_level(logging.ERROR):
+            result = notify([_make_update()])
+
+        assert result is False
+        assert "TELEGRAM_CHAT_ID" in caplog.text
+        mock_http_session.post.assert_not_called()
+
+    def test_both_config_missing_logs_error(self, mock_http_session, caplog):
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", ""), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", ""), \
+             caplog.at_level(logging.ERROR):
+            result = notify([_make_update()])
+
+        assert result is False
+        mock_http_session.post.assert_not_called()
+
+    def test_successful_send_returns_true(self, mock_http_session, caplog):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"), \
+             caplog.at_level(logging.INFO):
+            result = notify([_make_update()])
+
+        assert result is True
+        mock_http_session.post.assert_called_once()
+        assert "Telegram notification sent" in caplog.text
+
+    def test_failed_send_returns_false(self, mock_http_session, caplog):
+        mock_http_session.post.side_effect = Exception("timeout")
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"), \
+             caplog.at_level(logging.ERROR):
+            result = notify([_make_update()])
+
+        assert result is False
+        assert "Failed to send Telegram message" in caplog.text
+
+    def test_dry_run_logs_and_skips_http(self, mock_http_session, caplog):
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"), \
+             patch.object(config_mod, "DRY_RUN", True), \
+             caplog.at_level(logging.INFO):
+            result = notify([_make_update()])
+
+        assert result is True
+        mock_http_session.post.assert_not_called()
+        assert "DRY_RUN" in caplog.text
+
+    def test_only_mismatches_triggers_send(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            result = notify([], mismatches=[_make_mismatch()])
+
+        assert result is True
+        mock_http_session.post.assert_called_once()
+
+    def test_only_warnings_triggers_send(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            result = notify([], warnings=[_make_warning()])
+
+        assert result is True
+        mock_http_session.post.assert_called_once()
+
+    def test_long_update_list_sends_multiple_messages(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        # Generate enough updates to exceed 4096 chars
+        updates = [
+            _make_update(
+                container_name=f"container-{i}",
+                service_name=f"service-{i}",
+                stack=f"stack-{i}",
+                image=f"image-with-a-long-name-{i}",
+                current_version="1.0.0",
+                new_version="2.0.0",
+                status="new",
+            )
+            for i in range(60)
+        ]
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            result = notify(updates)
+
+        assert result is True
+        assert mock_http_session.post.call_count > 1
+
+    def test_partial_failure_returns_false(self, mock_http_session, caplog):
+        ok_resp = MagicMock()
+        ok_resp.raise_for_status.return_value = None
+        fail_side_effect = Exception("send failed")
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ok_resp
+            raise fail_side_effect
+
+        mock_http_session.post.side_effect = side_effect
+
+        updates = [
+            _make_update(
+                container_name=f"c{i}",
+                service_name=f"s{i}",
+                stack=f"st{i}",
+                image=f"img-{i}",
+                status="new",
+            )
+            for i in range(60)
+        ]
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"), \
+             caplog.at_level(logging.ERROR):
+            result = notify(updates)
+
+        assert result is False
+
+    def test_post_uses_markdownv2_parse_mode(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            notify([_make_update()])
+
+        call_kwargs = mock_http_session.post.call_args[1]
+        assert call_kwargs["json"]["parse_mode"] == "MarkdownV2"
+
+    def test_post_url_contains_bot_token(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "my-secret-token"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-100123"):
+            notify([_make_update()])
+
+        url = mock_http_session.post.call_args[0][0]
+        assert "my-secret-token" in url
+
+    def test_post_uses_correct_chat_id(self, mock_http_session):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_http_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "TELEGRAM_BOT_TOKEN", "tok123"), \
+             patch.object(config_mod, "TELEGRAM_CHAT_ID", "-9991234"):
+            notify([_make_update()])
+
+        call_kwargs = mock_http_session.post.call_args[1]
+        assert call_kwargs["json"]["chat_id"] == "-9991234"
+
+
+class TestDispatchTelegramChannel:
+    @patch("app.notifications.telegram_notify")
+    @patch("app.notifications.email_notify")
+    @patch("app.notifications.webhook_notify")
+    def test_telegram_channel_dispatched(self, mock_webhook, mock_email, mock_telegram):
+        updates = [_make_update()]
+        with patch.object(config_mod, "NOTIFY_CHANNELS", ["telegram"]):
+            dispatch(updates)
+
+        mock_telegram.assert_called_once_with(updates, mismatches=[], warnings=[])
+        mock_webhook.assert_not_called()
+        mock_email.assert_not_called()
+
+    @patch("app.notifications.telegram_notify")
+    @patch("app.notifications.email_notify")
+    @patch("app.notifications.webhook_notify")
+    def test_telegram_with_other_channels(self, mock_webhook, mock_email, mock_telegram):
+        updates = [_make_update()]
+        with patch.object(config_mod, "NOTIFY_CHANNELS", ["webhook", "telegram"]):
+            dispatch(updates)
+
+        mock_webhook.assert_called_once_with(updates, mismatches=[], warnings=[])
+        mock_telegram.assert_called_once_with(updates, mismatches=[], warnings=[])
+        mock_email.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds a `telegram` notification channel that sends MarkdownV2-formatted messages via the Telegram Bot API
- Messages are chunked to respect Telegram's 4096-character limit
- Updates `NOTIFY_CHANNELS` dispatch router, `app/config.py`, and all documentation/example files

## Changes

- `app/notifications/telegram.py` — new channel implementation with MarkdownV2 escaping, message building, and chunked sending
- `app/notifications/__init__.py` — wires `telegram` into the dispatch router
- `app/config.py` — adds `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` env vars
- `tests/test_notifications_telegram.py` — full test suite for the new channel
- `README.md` — documents new channel, env vars, and setup instructions
- `docker-compose.yml` — adds Telegram env vars alongside webhook/email sections
- `.env.example` — adds commented-out Telegram variables

## Test plan

- [x] `NOTIFY_CHANNELS=telegram` with valid bot token and chat ID sends a formatted message
- [x] Missing `TELEGRAM_BOT_TOKEN` or `TELEGRAM_CHAT_ID` logs an error and skips gracefully
- [x] Large payloads are split into multiple messages
- [x] `DRY_RUN=true` logs the message without sending
- [x] `.venv/bin/python -m pytest tests/test_notifications_telegram.py -v` passes