### PR TITLE
Add explicit digest mode via mode=digest label

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,26 @@ payload to a webhook when updates are found.
 ## How it works
 
 1. Reads all running containers from the Docker socket.
-2. For each container that has the `docker-update-monitor.tag-regex` label, it:
-   - Determines the current image tag.
-   - Fetches **all** available tags from Docker Hub in a single paginated sweep
-     (tags are cached per image, so multiple containers sharing the same image
-     only trigger one API call).
+2. For each monitored container it picks a detection mode:
+
+   **Semver mode** (container has `docker-update-monitor.tag-regex` and the current tag matches it)
+   - Fetches all available tags from the registry.
    - Applies your regex to parse version numbers from each tag.
-   - Finds the **best** (highest) update per level — one for patch, one for
-     minor, one for major — and deduplicates. You never receive intermediate
-     versions, only the latest available at each update level.
+   - Finds the **best** (highest) update per level — one for patch, one for minor, one for major.
+     You never receive intermediate versions, only the latest available at each level.
+
+   **Implicit digest mode** (container has `tag-regex` but the current tag does _not_ match it — e.g. `:latest`, `:edge`)
+   - Compares the registry manifest digest across scans.
+   - Silent on the first scan; reports a `digest` update when the digest changes on a later scan.
+   - Attempts to resolve the new digest to a versioned tag; falls back to the raw digest.
+
+   **Explicit digest mode** (container has `docker-update-monitor.mode: digest`)
+   - Compares the running image's local digest (`RepoDigests`) against the current registry digest via a single `HEAD` request.
+   - Works on the **first scan** — no silent warm-up scan required.
+   - For multi-arch images, falls back to a platform-specific digest check to avoid false positives when only another architecture's layer was updated.
+   - Can be combined with `tag-regex` to also resolve the new digest to a versioned tag.
+   - Takes precedence over semver detection when both labels are set.
+
 3. POSTs all found updates to your webhook endpoint.
 
 ---
@@ -70,7 +81,7 @@ services:
   sonarr:
     image: linuxserver/sonarr:4.0.2.1183
     labels:
-      # Required — regex with capture groups for (major, minor, patch)
+      # Required for semver detection — regex with capture groups for (major, minor, patch)
       docker-update-monitor.tag-regex: "^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$"
 
       # Optional — overrides auto-detected Compose project name
@@ -84,10 +95,35 @@ services:
     labels:
       docker-update-monitor.tag-regex: "^(\\d+)\\.(\\d+)\\.(\\d+)$"
 
-  # Containers WITHOUT the label are silently ignored
+  # Rolling-tag container monitored via explicit digest mode (no tag-regex needed)
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:latest
+    labels:
+      docker-update-monitor.mode: "digest"
+
+  # Rolling-tag with semver resolution: digest mode + tag-regex resolves the new
+  # digest to a versioned tag when one is available
+  myapp:
+    image: myregistry/myapp:edge
+    labels:
+      docker-update-monitor.mode: "digest"
+      docker-update-monitor.tag-regex: "^(\\d+)\\.(\\d+)\\.(\\d+)$"
+
+  # Containers WITHOUT any monitoring label are silently ignored
   redis:
     image: redis:7
 ```
+
+### Detection mode reference
+
+| Labels set | Tag matches regex? | Mode used |
+|---|---|---|
+| `tag-regex` only | Yes | Semver |
+| `tag-regex` only | No | Implicit digest (scan-to-scan comparison) |
+| `mode: digest` only | — | Explicit digest (RepoDigests vs registry) |
+| `mode: digest` + `tag-regex` | Any | Explicit digest (semver bypassed; regex used only for version resolution) |
+
+> **Explicit vs implicit digest:** The explicit `mode: digest` label compares the running image's local digest against the registry on every scan, including the first. The implicit fallback (tag doesn't match `tag-regex`) compares the registry digest across two consecutive scans and is silent on the first. Use `mode: digest` when your container exclusively uses rolling tags and you want immediate detection.
 
 ### Regex tips
 
@@ -137,7 +173,10 @@ update-level finding for one container:
 ]
 ```
 
-`update_type` is one of `patch`, `minor`, or `major`.
+`update_type` is one of `patch`, `minor`, `major`, or `digest`.
+
+For digest updates the `new_version` field contains either a resolved versioned tag (when one
+could be matched to the new digest) or the raw registry digest (`sha256:…`).
 
 ---
 
@@ -224,7 +263,7 @@ The monitor includes a built-in web dashboard accessible on port `8080` (configu
 - **Update table** — all detected updates with stack, container, image, versions, type, status, and first-seen date
 - **Sortable columns** — click any column header to sort; default sort is by stack
 - **Warnings section** — scan warnings and errors (invalid regex, missing tags, pattern mismatches)
-- **Not Monitored section** — collapsible list of containers without the `tag-regex` label, with reasons
+- **Not Monitored section** — collapsible list of containers without any monitoring label (`tag-regex` or `mode: digest`), with reasons
 - **Scan Now button** — trigger an immediate scan from the UI
 - **Auto-refresh** — polls for changes every 60 seconds
 - **Responsive** — works on desktop and mobile

--- a/app/registry/manifest.py
+++ b/app/registry/manifest.py
@@ -322,3 +322,147 @@ def fetch_digest(
 
     _digest_cache[cache_key] = result
     return result
+
+
+# ---------------------------------------------------------------------------
+# Platform-specific digest fetching (for multi-arch manifest lists)
+# ---------------------------------------------------------------------------
+
+# Cache: (image_name, tag, os, architecture) → digest string or None
+_platform_digest_cache: dict[tuple[str, str, str, str], Optional[str]] = {}
+
+
+def clear_platform_digest_cache() -> None:
+    """Clear the platform digest cache. Used in tests."""
+    _platform_digest_cache.clear()
+
+
+def _fetch_platform_digest_from_url(
+    url: str, auth_headers: dict, os: str, architecture: str
+) -> Optional[str]:
+    """GET the manifest URL and return the digest for the specified platform."""
+    headers = {
+        **auth_headers,
+        "Accept": (
+            "application/vnd.docker.distribution.manifest.list.v2+json,"
+            "application/vnd.oci.image.index.v1+json"
+        ),
+    }
+    try:
+        resp = _http.http_session.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        media_type = data.get("mediaType", "") or ""
+        manifests = None
+        if "manifest.list" in media_type or "image.index" in media_type:
+            manifests = data.get("manifests", [])
+        elif data.get("schemaVersion") == 2 and isinstance(data.get("manifests"), list):
+            manifests = data["manifests"]
+        if not manifests:
+            return None
+        for m in manifests:
+            platform = m.get("platform", {})
+            if platform.get("os") == os and platform.get("architecture") == architecture:
+                return m.get("digest") or None
+        return None
+    except requests.HTTPError as exc:
+        log.warning(f"Platform digest fetch HTTP error ({url}): {exc}")
+        return None
+    except Exception as exc:
+        log.warning(f"Platform digest fetch error ({url}): {exc}")
+        return None
+
+
+def _fetch_dockerhub_platform_digest(
+    image_name: str, tag: str, os: str, architecture: str,
+    username: str, password: str,
+) -> Optional[str]:
+    name = image_name.removeprefix("docker.io/")
+    parts = name.split("/")
+    if len(parts) == 1:
+        name = f"library/{name}"
+
+    scope = f"repository:{name}:pull"
+    token = _get_token(
+        "https://auth.docker.io/token",
+        service="registry.docker.io",
+        scope=scope,
+        username=username,
+        password=password,
+    )
+    if not token:
+        log.warning(f"DockerHub: could not obtain registry token for {name} — skipping platform digest fetch")
+        return None
+
+    url = f"https://registry-1.docker.io/v2/{name}/manifests/{tag}"
+    return _fetch_platform_digest_from_url(url, {"Authorization": f"Bearer {token}"}, os, architecture)
+
+
+def _fetch_ghcr_platform_digest(
+    image_name: str, tag: str, os: str, architecture: str, github_token: str,
+) -> Optional[str]:
+    if not github_token:
+        log.warning(f"GHCR: no GITHUB_TOKEN — skipping platform digest fetch for {image_name}")
+        return None
+
+    image_ref = image_name.strip()
+    parsed = urlparse(image_ref)
+
+    parsed_host = ""
+    if parsed.scheme and parsed.netloc:
+        parsed_host = (parsed.hostname or "").lower()
+    elif "/" in image_ref:
+        parsed_host = image_ref.split("/", 1)[0].lower()
+
+    host = "lscr.io" if parsed_host == "lscr.io" else "ghcr.io"
+    path = image_ref.removeprefix(f"{host}/")
+
+    scope = f"repository:{path}:pull"
+    reg_token = _get_token(
+        f"https://{host}/token",
+        service=host,
+        scope=scope,
+        bearer_token=github_token,
+    )
+    if not reg_token:
+        log.warning(f"GHCR: could not obtain registry token for {path} — skipping platform digest fetch")
+        return None
+
+    url = f"https://{host}/v2/{path}/manifests/{tag}"
+    return _fetch_platform_digest_from_url(url, {"Authorization": f"Bearer {reg_token}"}, os, architecture)
+
+
+def fetch_platform_digest(
+    image_name: str,
+    tag: str,
+    os: str,
+    architecture: str,
+    dockerhub_username: str,
+    dockerhub_password: str,
+    github_token: str,
+) -> Optional[str]:
+    """Return the digest of the platform-specific manifest entry for *os*/*architecture*.
+
+    Returns:
+        str: the digest of the matching platform manifest (e.g. "sha256:abc123...")
+        None: image is single-arch, platform not found in manifest list, or fetch failed.
+
+    Results are cached per (image_name, tag, os, architecture).
+    """
+    cache_key = (image_name, tag, os, architecture)
+    if cache_key in _platform_digest_cache:
+        return _platform_digest_cache[cache_key]
+
+    registry = detect_registry(image_name)
+    if registry == "dockerhub":
+        result = _fetch_dockerhub_platform_digest(
+            image_name, tag, os, architecture, dockerhub_username, dockerhub_password
+        )
+    elif registry == "ghcr":
+        result = _fetch_ghcr_platform_digest(image_name, tag, os, architecture, github_token)
+    else:
+        log.debug(f"Unknown registry for '{image_name}' — skipping platform digest fetch")
+        result = None
+
+    _platform_digest_cache[cache_key] = result
+    return result

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -11,11 +11,25 @@ from app.cooldown import parse_cooldown
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
 from app.registry import fetch_all_tags
 from app.registry.dockerhub import get_dockerhub_token
-from app.registry.manifest import fetch_manifest_list, is_platform_supported, fetch_digest
+from app.registry.manifest import fetch_manifest_list, is_platform_supported, fetch_digest, fetch_platform_digest
 from app.version import find_updates
 from app.notifications import dispatch as notify
 from app.state import process_scan, mark_notified, get_stored_digest, store_digest
 from app.health import update_state
+
+
+def _extract_local_digest(repo_digests: list[str]) -> str | None:
+    """Extract the first sha256 digest from a Docker RepoDigests list.
+
+    RepoDigests entries use the format "image@sha256:digest".
+    Returns the digest portion (e.g. "sha256:abc123...") of the first valid entry.
+    """
+    for entry in repo_digests:
+        if "@" in entry:
+            _, digest = entry.split("@", 1)
+            if digest.startswith("sha256:"):
+                return digest
+    return None
 
 
 def _resolve_digest_to_tag(
@@ -97,9 +111,10 @@ def run_check() -> None:
     for container in containers:
         container_name: str = container.name or ""
         labels  = container.labels
+        mode    = labels.get(f"{_config.LABEL_PREFIX}.mode", "").lower()
         pattern = labels.get(f"{_config.LABEL_PREFIX}.tag-regex")
 
-        if not pattern:
+        if not pattern and mode != "digest":
             _config.log.debug(f"  [{container_name}] No '{_config.LABEL_PREFIX}.tag-regex' label — skipping")
             # Determine image for display
             skip_image = ""
@@ -132,15 +147,16 @@ def run_check() -> None:
             )
             container_cooldowns[container_name] = parse_cooldown("0")
 
-        try:
-            re.compile(pattern)
-        except re.error as exc:
-            msg = f"Invalid tag-regex '{pattern}': {exc}"
-            _config.log.warning(f"  [{container_name}] {msg} — skipping")
-            all_warnings.append(ScanWarning(
-                container_name=container_name, image="", level="warning", message=msg,
-            ))
-            continue
+        if pattern:
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                msg = f"Invalid tag-regex '{pattern}': {exc}"
+                _config.log.warning(f"  [{container_name}] {msg} — skipping")
+                all_warnings.append(ScanWarning(
+                    container_name=container_name, image="", level="warning", message=msg,
+                ))
+                continue
 
         # Resolve full image reference
         image_ref = None
@@ -180,6 +196,98 @@ def run_check() -> None:
         service_name = labels.get("com.docker.compose.service", "")
 
         _config.log.info(f"  [{container_name}]  image={image_name}:{current_tag}  stack={stack}")
+
+        if mode == "digest":
+            # Explicit digest mode: compare the local running image digest (RepoDigests)
+            # against the remote registry digest via HEAD request.  Works on first scan —
+            # no need for a silent storage phase.
+            repo_digests = container.image.attrs.get("RepoDigests") or []
+            local_digest = _extract_local_digest(repo_digests)
+
+            if not local_digest:
+                msg = f"No RepoDigests available for {image_name}:{current_tag} — cannot compare"
+                _config.log.warning(f"    {msg}")
+                all_warnings.append(ScanWarning(
+                    container_name=container_name, image=image_name, level="warning", message=msg,
+                ))
+                monitored_versions[(container_name, image_name)] = (current_tag, pattern or "")
+                running_digests[(container_name, image_name)] = repo_digests
+                continue
+
+            remote_digest = fetch_digest(
+                image_name, current_tag,
+                _config.DOCKERHUB_USER, _config.DOCKERHUB_PASS,
+                _config.GITHUB_TOKEN,
+            )
+            if not remote_digest:
+                msg = f"Could not fetch remote digest for {image_name}:{current_tag}"
+                _config.log.warning(f"    {msg}")
+                all_warnings.append(ScanWarning(
+                    container_name=container_name, image=image_name, level="warning", message=msg,
+                ))
+                monitored_versions[(container_name, image_name)] = (current_tag, pattern or "")
+                running_digests[(container_name, image_name)] = repo_digests
+                continue
+
+            if local_digest == remote_digest:
+                _config.log.info(f"    Digest up to date ({local_digest[:19]})")
+            else:
+                # Multi-arch: the manifest list digest may differ from the platform-specific
+                # digest stored in RepoDigests.  Check whether the platform-specific digest
+                # is unchanged before reporting an update.
+                platform_match = False
+                try:
+                    image_attrs = container.image.attrs or {}
+                    container_os = image_attrs.get("Os", "") or ""
+                    container_arch = image_attrs.get("Architecture", "") or ""
+                    if container_os and container_arch:
+                        platform_digest = fetch_platform_digest(
+                            image_name, current_tag,
+                            container_os, container_arch,
+                            _config.DOCKERHUB_USER, _config.DOCKERHUB_PASS,
+                            _config.GITHUB_TOKEN,
+                        )
+                        if platform_digest and platform_digest == local_digest:
+                            platform_match = True
+                            _config.log.info(
+                                f"    Platform digest unchanged for"
+                                f" {container_os}/{container_arch} ({local_digest[:19]})"
+                            )
+                except Exception as exc:
+                    _config.log.debug(f"    Could not check platform digest: {exc}")
+
+                if not platform_match:
+                    _config.log.info(
+                        f"    Digest changed: {local_digest[:19]} → {remote_digest[:19]}"
+                    )
+                    # Optionally resolve the new digest to a versioned tag
+                    resolved_version = None
+                    if pattern:
+                        cache_key = (image_name, current_tag)
+                        if cache_key not in tags_cache:
+                            tags_cache[cache_key] = fetch_all_tags(
+                                image_name, token, _config.GITHUB_TOKEN, current_tag
+                            )
+                        all_tags = tags_cache[cache_key]
+                        if all_tags:
+                            resolved_version = _resolve_digest_to_tag(
+                                image_name, remote_digest, all_tags, pattern,
+                                current_tag=current_tag,
+                            )
+                    new_version = resolved_version or remote_digest
+                    all_updates.append(UpdateInfo(
+                        container_name=container_name,
+                        service_name=service_name,
+                        stack=stack,
+                        image=image_name,
+                        current_version=current_tag,
+                        new_version=new_version,
+                        update_type="digest",
+                    ))
+
+            monitored_versions[(container_name, image_name)] = (current_tag, pattern or "")
+            running_digests[(container_name, image_name)] = repo_digests
+            continue
 
         # Fetch tags once per unique (image, tag) combination
         cache_key = (image_name, current_tag)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,15 @@ services:
 
       # Label namespace (default: docker-update-monitor)
       # LABEL_PREFIX: "docker-update-monitor"
-      # Only docker containers with docker-update-monitor.tag-regex are monitored
-      # Example: "docker-update-monitor.tag-regex=^v?\\d+\\.\\
+      # Containers are monitored when they carry at least one of these labels:
+      #   docker-update-monitor.tag-regex  — semver detection (and implicit digest fallback
+      #                                      when the current tag does not match the regex)
+      #   docker-update-monitor.mode=digest — explicit digest mode: compares the running
+      #                                       image's RepoDigests against the registry on
+      #                                       every scan; works from the first scan without
+      #                                       a silent warm-up. Can be combined with
+      #                                       tag-regex to resolve the new digest to a
+      #                                       versioned tag.
 
       # Log verbosity: DEBUG | INFO | WARNING | ERROR
       LOG_LEVEL: "INFO"

--- a/tests/test_digest_detection.py
+++ b/tests/test_digest_detection.py
@@ -7,7 +7,7 @@ import pytest
 
 from app import config as config_mod
 from app.models import UpdateInfo
-from app.scanner import run_check, _resolve_digest_to_tag
+from app.scanner import run_check, _resolve_digest_to_tag, _extract_local_digest
 from app.state import get_stored_digest, store_digest, process_scan, get_active_updates
 
 
@@ -447,3 +447,418 @@ class TestDigestFetchFailure:
             run_check()
 
         assert "Could not fetch digest" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Tests for _extract_local_digest helper
+# ---------------------------------------------------------------------------
+
+class TestExtractLocalDigest:
+    def test_standard_format(self):
+        assert _extract_local_digest(["nginx@sha256:abc123"]) == "sha256:abc123"
+
+    def test_registry_prefixed_format(self):
+        assert _extract_local_digest(
+            ["ghcr.io/myorg/myimage@sha256:def456"]
+        ) == "sha256:def456"
+
+    def test_multiple_entries_returns_first(self):
+        result = _extract_local_digest([
+            "nginx@sha256:first111",
+            "docker.io/library/nginx@sha256:second222",
+        ])
+        assert result == "sha256:first111"
+
+    def test_empty_list(self):
+        assert _extract_local_digest([]) is None
+
+    def test_no_at_sign(self):
+        assert _extract_local_digest(["nginx:latest"]) is None
+
+    def test_non_sha256_digest_skipped(self):
+        assert _extract_local_digest(["nginx@md5:abc"]) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for mode=digest label (explicit digest mode using RepoDigests)
+# ---------------------------------------------------------------------------
+
+class TestDigestModeLabel:
+    """mode=digest label compares local RepoDigests against the remote registry digest."""
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest", return_value="sha256:local111")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_digests_match_no_update(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify
+    ):
+        """No update when local RepoDigests matches remote digest."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {"RepoDigests": ["myimage@sha256:local111"], "Os": "", "Architecture": ""}
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        if mock_notify.called:
+            updates_arg = mock_notify.call_args[0][0]
+            digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+            assert len(digest_updates) == 0
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest", return_value="sha256:remote222")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_digests_differ_reports_update(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify
+    ):
+        """Update reported on first scan when local digest differs from remote."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:local111"],
+            "Os": "",
+            "Architecture": "",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch("app.scanner.fetch_platform_digest", return_value=None):
+            run_check()
+
+        assert mock_notify.called
+        updates_arg = mock_notify.call_args[0][0]
+        digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+        assert len(digest_updates) == 1
+        assert digest_updates[0].current_version == "latest"
+        assert digest_updates[0].new_version == "sha256:remote222"
+        assert digest_updates[0].image == "myimage"
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "1.1.0", "latest"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_with_tag_regex_resolves_to_version(
+        self, mock_docker, mock_token, mock_fetch_tags, mock_fetch_digest, mock_notify
+    ):
+        """When tag-regex is also set, the new digest resolves to a versioned tag."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {
+                "docker-update-monitor.mode": "digest",
+                "docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$",
+            },
+        )
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:olddigest000"],
+            "Os": "",
+            "Architecture": "",
+        }
+
+        def digest_side_effect(image, tag, *args, **kwargs):
+            if tag == "latest":
+                return "sha256:newdigest111"
+            if tag == "1.1.0":
+                return "sha256:newdigest111"
+            return "sha256:other"
+
+        mock_fetch_digest.side_effect = digest_side_effect
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch("app.scanner.fetch_platform_digest", return_value=None):
+            run_check()
+
+        assert mock_notify.called
+        updates_arg = mock_notify.call_args[0][0]
+        digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+        assert len(digest_updates) == 1
+        assert digest_updates[0].new_version == "1.1.0"
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest", return_value="sha256:remote222")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_no_repo_digests_produces_warning(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify, caplog
+    ):
+        """A warning is produced when RepoDigests is empty."""
+        import logging
+
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {"RepoDigests": [], "Os": "", "Architecture": ""}
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.WARNING):
+            run_check()
+
+        assert "No RepoDigests" in caplog.text
+        if mock_notify.called:
+            updates_arg = mock_notify.call_args[0][0]
+            digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+            assert len(digest_updates) == 0
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest", return_value=None)
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_remote_digest_fetch_failure_produces_warning(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify, caplog
+    ):
+        """A warning is produced when the remote digest cannot be fetched."""
+        import logging
+
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:local111"],
+            "Os": "",
+            "Architecture": "",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.WARNING):
+            run_check()
+
+        assert "Could not fetch remote digest" in caplog.text
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_mode_digest_without_tag_regex(
+        self, mock_docker, mock_token, mock_notify
+    ):
+        """mode=digest works without a tag-regex label."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:local111"],
+            "Os": "",
+            "Architecture": "",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch("app.scanner.fetch_digest", return_value="sha256:local111"):
+            run_check()
+
+        # Digests match — no update expected
+        if mock_notify.called:
+            updates_arg = mock_notify.call_args[0][0]
+            digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+            assert len(digest_updates) == 0
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_multiarch_platform_digest_match_suppresses_update(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify
+    ):
+        """No update when manifest list digest differs but platform digest matches local."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        # Local RepoDigests has the platform-specific digest
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:platform-amd64"],
+            "Os": "linux",
+            "Architecture": "amd64",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        # Remote returns a different manifest list digest (another platform was updated)
+        mock_fetch_digest.return_value = "sha256:new-manifest-list"
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch("app.scanner.fetch_platform_digest", return_value="sha256:platform-amd64"):
+            run_check()
+
+        # Platform-specific digest unchanged → no update
+        if mock_notify.called:
+            updates_arg = mock_notify.call_args[0][0]
+            digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+            assert len(digest_updates) == 0
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_multiarch_platform_digest_changed_reports_update(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify
+    ):
+        """Update reported when the platform-specific digest also changed."""
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:old-platform-amd64"],
+            "Os": "linux",
+            "Architecture": "amd64",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        mock_fetch_digest.return_value = "sha256:new-manifest-list"
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch("app.scanner.fetch_platform_digest", return_value="sha256:new-platform-amd64"):
+            run_check()
+
+        assert mock_notify.called
+        updates_arg = mock_notify.call_args[0][0]
+        digest_updates = [u for u in updates_arg if u.update_type == "digest"]
+        assert len(digest_updates) == 1
+        assert digest_updates[0].new_version == "sha256:new-manifest-list"
+
+
+class TestDigestModeAutoResolveAfterRepull:
+    """mode=digest containers auto-resolve after repull, same as implicit digest mode."""
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_digest", return_value="sha256:remote222")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_repulled_container_resolves_pending_update(
+        self, mock_docker, mock_token, mock_fetch_digest, mock_notify
+    ):
+        container = _make_container(
+            "myapp", "myimage:latest",
+            {"docker-update-monitor.mode": "digest"},
+        )
+        # Container now runs the updated image
+        container.image.attrs = {
+            "RepoDigests": ["myimage@sha256:remote222"],
+            "Os": "",
+            "Architecture": "",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+
+        # Pre-create a pending digest update in the DB (simulating prior scan)
+        store_digest("myimage", "latest", "sha256:remote222")
+        process_scan([UpdateInfo(
+            container_name="myapp", service_name="", stack="standalone",
+            image="myimage", current_version="latest",
+            new_version="sha256:remote222", update_type="digest",
+        )])
+        assert len(get_active_updates()) == 1
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # Pending update should be resolved
+        assert len(get_active_updates()) == 0
+
+
+class TestFetchPlatformDigest:
+    """Unit tests for the fetch_platform_digest function in manifest.py."""
+
+    def test_returns_platform_specific_digest(self):
+        from app.registry.manifest import _fetch_platform_digest_from_url
+
+        manifest_data = {
+            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+            "manifests": [
+                {"digest": "sha256:amd64digest", "platform": {"os": "linux", "architecture": "amd64"}},
+                {"digest": "sha256:arm64digest", "platform": {"os": "linux", "architecture": "arm64"}},
+            ],
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = manifest_data
+
+        with patch("app.registry.manifest._http") as mock_http:
+            mock_http.http_session.get.return_value = mock_resp
+            result = _fetch_platform_digest_from_url(
+                "https://example.com/v2/img/manifests/latest",
+                {},
+                "linux", "amd64",
+            )
+
+        assert result == "sha256:amd64digest"
+
+    def test_returns_none_for_missing_platform(self):
+        from app.registry.manifest import _fetch_platform_digest_from_url
+
+        manifest_data = {
+            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+            "manifests": [
+                {"digest": "sha256:arm64digest", "platform": {"os": "linux", "architecture": "arm64"}},
+            ],
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = manifest_data
+
+        with patch("app.registry.manifest._http") as mock_http:
+            mock_http.http_session.get.return_value = mock_resp
+            result = _fetch_platform_digest_from_url(
+                "https://example.com/v2/img/manifests/latest",
+                {},
+                "linux", "amd64",
+            )
+
+        assert result is None
+
+    def test_returns_none_for_single_arch_image(self):
+        from app.registry.manifest import _fetch_platform_digest_from_url
+
+        manifest_data = {
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "layers": [],
+        }
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = manifest_data
+
+        with patch("app.registry.manifest._http") as mock_http:
+            mock_http.http_session.get.return_value = mock_resp
+            result = _fetch_platform_digest_from_url(
+                "https://example.com/v2/img/manifests/latest",
+                {},
+                "linux", "amd64",
+            )
+
+        assert result is None


### PR DESCRIPTION
## Summary
- Introduces `docker-update-monitor.mode=digest` as a first-class label for monitoring containers with rolling tags (`:latest`, `:edge`, date-based tags)
- Detects updates on the **first scan** by comparing the running image's `RepoDigests` against the remote registry digest via `HEAD` request — no silent warm-up scan required
- Handles multi-arch images: checks the platform-specific digest to avoid false positives when only another architecture's layer was updated
- Can be combined with `tag-regex` to resolve the new digest to a versioned tag

## Changes
- `app/registry/manifest.py`: added `fetch_platform_digest()` and supporting helpers to retrieve the digest of a specific platform's manifest entry from a multi-arch manifest list; cached per `(image, tag, os, arch)`
- `app/scanner.py`: added `_extract_local_digest()` helper to parse `image@sha256:…` RepoDigests entries; added `mode=digest` branch in the container loop; made `tag-regex` optional when `mode=digest` is set; `mode=digest` takes precedence over semver when both labels are present
- `tests/test_digest_detection.py`: added `TestExtractLocalDigest`, `TestDigestModeLabel` (8 scenarios), `TestDigestModeAutoResolveAfterRepull`, and `TestFetchPlatformDigest`
- `README.md`: documented all three detection modes, added decision table, updated labelling examples and webhook payload description
- `docker-compose.yml`: updated `LABEL_PREFIX` comment to reflect both monitoring labels

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 422 tests
- [x] `mode=digest` without `tag-regex`: container is monitored, update reported on first scan when digests differ
- [x] `mode=digest` with `tag-regex`: digest takes precedence; new digest resolved to versioned tag when available
- [x] Multi-arch: platform digest match suppresses update; platform digest change reports update
- [x] No `RepoDigests` available: warning produced, no update reported
- [x] Remote digest fetch failure: warning produced, no update reported
- [x] Pending digest update resolves after container repulls the updated image
- [x] Existing semver and implicit digest paths are unaffected