### PR TITLE
Add Prometheus metrics endpoint (GET /metrics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,29 @@ Then open `http://<your-host>:8080` in a browser.
 | `GET`  | `/health`      | Health check (JSON) — used by Docker HEALTHCHECK |
 | `GET`  | `/api/updates` | All updates with status as JSON array            |
 | `POST` | `/api/scan`    | Trigger immediate scan, returns 202 Accepted     |
+| `GET`  | `/metrics`     | Prometheus metrics (text/plain)                  |
+
+### Prometheus metrics
+
+`GET /metrics` exposes the following metrics in Prometheus text format, updated after each scan:
+
+| Metric | Type | Description |
+| ------ | ---- | ----------- |
+| `dum_containers_monitored` | Gauge | Number of containers with update-monitor labels |
+| `dum_updates_available{type}` | Gauge | Active (non-resolved) updates by type (`patch`, `minor`, `major`, `digest`) |
+| `dum_check_duration_seconds` | Gauge | Duration of the last update check in seconds |
+| `dum_check_errors_total` | Counter | Total errors encountered during checks (Docker connection failures, registry warnings) |
+| `dum_last_check_timestamp_seconds` | Gauge | Unix timestamp of the last completed check |
+| `dum_notifications_sent_total{channel}` | Counter | Total notification dispatches by channel (`webhook`, `email`) |
+
+Example Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: docker-update-monitor
+    static_configs:
+      - targets: ["<your-host>:8080"]
+```
 
 ### Environment variable
 

--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -4,7 +4,8 @@ import threading
 from datetime import datetime
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from flask import Flask, jsonify, render_template
+from flask import Flask, Response, jsonify, render_template
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 import app.config as _config
 from app.health import update_state, _state, _state_lock, _build_response
@@ -101,6 +102,10 @@ def create_app() -> Flask:
         with _state_lock:
             last_check = _state.get("last_check")
         return jsonify({"last_check": last_check})
+
+    @application.route("/metrics")
+    def metrics():
+        return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
 
     return application
 

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,76 @@
+"""Prometheus metrics for Docker Update Monitor."""
+
+from prometheus_client import Counter, Gauge
+
+containers_monitored = Gauge(
+    "dum_containers_monitored",
+    "Number of containers with update-monitor labels",
+)
+
+updates_available = Gauge(
+    "dum_updates_available",
+    "Number of available updates by type",
+    ["type"],
+)
+
+check_duration_seconds = Gauge(
+    "dum_check_duration_seconds",
+    "Duration of the last update check",
+)
+
+check_errors_total = Counter(
+    "dum_check_errors_total",
+    "Total number of errors during checks",
+)
+
+last_check_timestamp_seconds = Gauge(
+    "dum_last_check_timestamp_seconds",
+    "Unix timestamp of last completed check",
+)
+
+notifications_sent_total = Counter(
+    "dum_notifications_sent_total",
+    "Total notifications sent by channel",
+    ["channel"],
+)
+
+# Tracks which update_type labels have been set, so we can zero them out when
+# they are no longer present after a scan.
+_seen_update_types: set[str] = set()
+
+
+def update_after_scan(
+    *,
+    monitored: int,
+    updates: list,
+    duration_seconds: float,
+    last_check_ts: float,
+) -> None:
+    """Update gauge metrics with the latest scan results.
+
+    ``updates`` is a list of dicts (from get_all_updates()) or UpdateInfo objects.
+    """
+    global _seen_update_types
+
+    containers_monitored.set(monitored)
+    last_check_timestamp_seconds.set(last_check_ts)
+    check_duration_seconds.set(duration_seconds)
+
+    by_type: dict[str, int] = {}
+    for u in updates:
+        if isinstance(u, dict):
+            status = u.get("status", "")
+            utype = u.get("update_type", "unknown")
+        else:
+            status = u.status
+            utype = u.update_type
+        if status != "resolved":
+            by_type[utype] = by_type.get(utype, 0) + 1
+
+    for t in _seen_update_types - set(by_type):
+        updates_available.labels(type=t).set(0)
+
+    for t, count in by_type.items():
+        updates_available.labels(type=t).set(count)
+
+    _seen_update_types = set(by_type.keys())

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -2,6 +2,7 @@ import app.config as _config
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
 from app.notifications.webhook import notify as webhook_notify
 from app.notifications.email import notify as email_notify
+from app.metrics import notifications_sent_total
 
 
 def dispatch(
@@ -17,7 +18,9 @@ def dispatch(
     for channel in _config.NOTIFY_CHANNELS:
         if channel == "webhook":
             webhook_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
+            notifications_sent_total.labels(channel="webhook").inc()
         elif channel == "email":
             email_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
+            notifications_sent_total.labels(channel="email").inc()
         else:
             _config.log.warning(f"Unknown notification channel '{channel}' — skipping")

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -1,4 +1,5 @@
 import re
+import time
 from datetime import datetime, timedelta, timezone
 
 _GIT_HASH_RE = re.compile(r"sha-[a-f0-9]{7,}")
@@ -14,8 +15,9 @@ from app.registry.dockerhub import get_dockerhub_token
 from app.registry.manifest import fetch_manifest_list, is_platform_supported, fetch_digest, fetch_platform_digest
 from app.version import find_updates
 from app.notifications import dispatch as notify
-from app.state import process_scan, mark_notified, get_stored_digest, store_digest
+from app.state import process_scan, mark_notified, get_stored_digest, store_digest, get_all_updates
 from app.health import update_state
+from app.metrics import check_errors_total, update_after_scan
 
 
 def _extract_local_digest(repo_digests: list[str]) -> str | None:
@@ -80,10 +82,13 @@ def run_check() -> None:
     _config.log.info("Starting update check")
     _config.log.info("=" * 60)
 
+    _scan_start = time.monotonic()
+
     try:
         client = docker.from_env()
     except DockerException as exc:
         _config.log.error(f"Cannot connect to Docker: {exc}")
+        check_errors_total.inc()
         return
 
     token = get_dockerhub_token(_config.DOCKERHUB_USER, _config.DOCKERHUB_PASS)
@@ -482,6 +487,16 @@ def run_check() -> None:
     notify(actionable, mismatches=all_mismatches, warnings=all_warnings)
     if actionable:
         mark_notified(actionable, scan_time)
+
+    # Update Prometheus metrics
+    if all_warnings:
+        check_errors_total.inc(len(all_warnings))
+    update_after_scan(
+        monitored=monitored_count,
+        updates=get_all_updates(),
+        duration_seconds=time.monotonic() - _scan_start,
+        last_check_ts=scan_time.timestamp(),
+    )
 
     # Update health endpoint state
     warnings_data = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       DASHBOARD_DATETIME_FORMAT: "${DASHBOARD_DATETIME_FORMAT:-%d/%m/%Y %H:%M}"
 
     ports:
-      # Expose the web dashboard
+      # Expose the web dashboard and /metrics endpoint
       - "8080:8080"
 
     volumes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.33.1
 croniter>=6.2.2
 flask>=3.1.3
 waitress>=3.0.0
+prometheus_client>=0.21.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,234 @@
+"""Tests for Prometheus metrics module and /metrics endpoint."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+import app.metrics as metrics_mod
+from app.metrics import (
+    containers_monitored,
+    updates_available,
+    check_duration_seconds,
+    check_errors_total,
+    last_check_timestamp_seconds,
+    notifications_sent_total,
+    update_after_scan,
+)
+from app.models import UpdateInfo
+
+
+@pytest.fixture(autouse=True)
+def reset_seen_types():
+    """Reset the _seen_update_types tracking set and zero all update_type gauges between tests."""
+    metrics_mod._seen_update_types = set()
+    for child in list(metrics_mod.updates_available._metrics.values()):
+        child.set(0)
+    yield
+    metrics_mod._seen_update_types = set()
+
+
+@pytest.fixture
+def client():
+    """Flask test client with the full app."""
+    from app.dashboard import create_app
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestUpdateAfterScanGauges:
+    """update_after_scan() sets gauge values correctly."""
+
+    def test_sets_containers_monitored(self):
+        update_after_scan(monitored=7, updates=[], duration_seconds=0.0, last_check_ts=0.0)
+        assert containers_monitored._value.get() == 7.0
+
+    def test_sets_check_duration(self):
+        update_after_scan(monitored=0, updates=[], duration_seconds=14.2, last_check_ts=0.0)
+        assert abs(check_duration_seconds._value.get() - 14.2) < 1e-6
+
+    def test_sets_last_check_timestamp(self):
+        update_after_scan(monitored=0, updates=[], duration_seconds=0.0, last_check_ts=1714300800.0)
+        assert last_check_timestamp_seconds._value.get() == 1714300800.0
+
+    def test_counts_updates_by_type_from_dicts(self):
+        updates = [
+            {"status": "new", "update_type": "patch"},
+            {"status": "known", "update_type": "patch"},
+            {"status": "new", "update_type": "minor"},
+        ]
+        update_after_scan(monitored=3, updates=updates, duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="patch")._value.get() == 2.0
+        assert updates_available.labels(type="minor")._value.get() == 1.0
+
+    def test_counts_updates_by_type_from_update_info_objects(self):
+        u1 = UpdateInfo("c1", "s", "st", "img", "1.0", "2.0", "major", status="new")
+        u2 = UpdateInfo("c2", "s", "st", "img", "1.0", "1.1", "minor", status="known")
+        update_after_scan(monitored=2, updates=[u1, u2], duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="major")._value.get() == 1.0
+        assert updates_available.labels(type="minor")._value.get() == 1.0
+
+    def test_resolved_updates_excluded_from_count(self):
+        updates = [{"status": "resolved", "update_type": "major"}]
+        update_after_scan(monitored=1, updates=updates, duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="major")._value.get() == 0.0
+
+    def test_zeroes_out_types_no_longer_present(self):
+        updates1 = [
+            {"status": "new", "update_type": "patch"},
+            {"status": "known", "update_type": "patch"},
+        ]
+        update_after_scan(monitored=2, updates=updates1, duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="patch")._value.get() == 2.0
+
+        update_after_scan(monitored=0, updates=[], duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="patch")._value.get() == 0.0
+
+    def test_multiple_update_types(self):
+        updates = [
+            {"status": "new", "update_type": "patch"},
+            {"status": "new", "update_type": "minor"},
+            {"status": "new", "update_type": "minor"},
+            {"status": "new", "update_type": "major"},
+            {"status": "new", "update_type": "digest"},
+        ]
+        update_after_scan(monitored=5, updates=updates, duration_seconds=0.0, last_check_ts=0.0)
+        assert updates_available.labels(type="patch")._value.get() == 1.0
+        assert updates_available.labels(type="minor")._value.get() == 2.0
+        assert updates_available.labels(type="major")._value.get() == 1.0
+        assert updates_available.labels(type="digest")._value.get() == 1.0
+
+
+class TestCheckErrorsCounter:
+    """check_errors_total increments correctly."""
+
+    def test_increments_on_explicit_call(self):
+        before = check_errors_total._value.get()
+        check_errors_total.inc()
+        assert check_errors_total._value.get() == before + 1.0
+
+    def test_increments_by_n(self):
+        before = check_errors_total._value.get()
+        check_errors_total.inc(3)
+        assert check_errors_total._value.get() == before + 3.0
+
+    def test_scanner_increments_on_docker_failure(self):
+        from docker.errors import DockerException
+        before = check_errors_total._value.get()
+        with patch("app.scanner.docker.from_env", side_effect=DockerException("fail")):
+            from app.scanner import run_check
+            run_check()
+        assert check_errors_total._value.get() == before + 1.0
+
+    def test_scanner_increments_for_warnings(self):
+        """Each ScanWarning produced during a scan increments the error counter."""
+        from app.scanner import run_check
+
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_container.name = "broken"
+        mock_container.labels = {
+            "docker-update-monitor.tag-regex": "(",  # invalid regex → warning
+        }
+        mock_container.image.tags = ["nginx:latest"]
+        mock_container.attrs = {"Config": {"Image": "nginx:latest"}}
+        mock_client.containers.list.return_value = [mock_container]
+
+        before = check_errors_total._value.get()
+        with patch("app.scanner.docker.from_env", return_value=mock_client), \
+             patch("app.scanner.get_dockerhub_token", return_value=None):
+            run_check()
+        assert check_errors_total._value.get() > before
+
+
+class TestNotificationsSentCounter:
+    """notifications_sent_total increments per channel dispatch."""
+
+    def test_increments_webhook_channel(self):
+        before = notifications_sent_total.labels(channel="webhook")._value.get()
+        with patch("app.notifications.webhook_notify"), \
+             patch("app.config.NOTIFY_CHANNELS", ["webhook"]):
+            from app.notifications import dispatch
+            u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
+            dispatch([u])
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before + 1.0
+
+    def test_increments_email_channel(self):
+        before = notifications_sent_total.labels(channel="email")._value.get()
+        with patch("app.notifications.email_notify"), \
+             patch("app.config.NOTIFY_CHANNELS", ["email"]):
+            from app.notifications import dispatch
+            u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
+            dispatch([u])
+        assert notifications_sent_total.labels(channel="email")._value.get() == before + 1.0
+
+    def test_no_increment_when_nothing_to_notify(self):
+        before_w = notifications_sent_total.labels(channel="webhook")._value.get()
+        before_e = notifications_sent_total.labels(channel="email")._value.get()
+        with patch("app.config.NOTIFY_CHANNELS", ["webhook", "email"]):
+            from app.notifications import dispatch
+            dispatch([])
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_w
+        assert notifications_sent_total.labels(channel="email")._value.get() == before_e
+
+
+class TestMetricsEndpoint:
+    """GET /metrics returns valid Prometheus text format."""
+
+    def test_returns_200(self, client):
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+    def test_content_type_is_prometheus(self, client):
+        resp = client.get("/metrics")
+        assert "text/plain" in resp.content_type
+
+    def test_contains_dum_containers_monitored(self, client):
+        update_after_scan(monitored=3, updates=[], duration_seconds=1.0, last_check_ts=100.0)
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_containers_monitored" in body
+
+    def test_contains_dum_updates_available(self, client):
+        updates = [{"status": "new", "update_type": "minor"}]
+        update_after_scan(monitored=1, updates=updates, duration_seconds=1.0, last_check_ts=100.0)
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_updates_available" in body
+        assert 'type="minor"' in body
+
+    def test_contains_dum_check_duration_seconds(self, client):
+        update_after_scan(monitored=0, updates=[], duration_seconds=5.5, last_check_ts=100.0)
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_check_duration_seconds" in body
+
+    def test_contains_dum_check_errors_total(self, client):
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_check_errors_total" in body
+
+    def test_contains_dum_last_check_timestamp_seconds(self, client):
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_last_check_timestamp_seconds" in body
+
+    def test_contains_dum_notifications_sent_total(self, client):
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_notifications_sent_total" in body
+
+    def test_metric_values_reflect_last_scan(self, client):
+        import re
+        updates = [
+            {"status": "new", "update_type": "patch"},
+            {"status": "new", "update_type": "patch"},
+            {"status": "new", "update_type": "major"},
+        ]
+        update_after_scan(monitored=12, updates=updates, duration_seconds=14.2, last_check_ts=1714300800.0)
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_containers_monitored 12.0" in body
+        m = re.search(r"^dum_last_check_timestamp_seconds (\S+)", body, re.MULTILINE)
+        assert m is not None
+        assert abs(float(m.group(1)) - 1714300800.0) < 1.0


### PR DESCRIPTION
## Summary
- Exposes a `GET /metrics` endpoint in Prometheus text format on the existing `WEB_PORT`, enabling Grafana dashboard and Alertmanager integration without custom exporters
- Implements all six metrics from the issue spec: container count, updates-by-type, scan duration, error total, last-check timestamp, and notifications-sent-by-channel

## Changes
- `app/metrics.py` (new): defines all six `prometheus_client` metric objects (`Gauge`/`Counter`) and `update_after_scan()` helper that refreshes gauge values after each scan, zeroing out update types that are no longer present
- `app/dashboard.py`: adds `GET /metrics` route using `generate_latest()` / `CONTENT_TYPE_LATEST`
- `app/scanner.py`: tracks scan start time with `time.monotonic()`, calls `update_after_scan()` at scan completion, and increments `dum_check_errors_total` on Docker connection failure and for each `ScanWarning` produced
- `app/notifications/__init__.py`: increments `dum_notifications_sent_total{channel}` after each successful dispatch
- `requirements.txt`: adds `prometheus_client>=0.21.0`
- `README.md`: documents the new endpoint in the API table and adds a dedicated Prometheus metrics section with scrape config example
- `docker-compose.yml`: updates port comment to mention `/metrics`
- `tests/test_metrics.py` (new): 24 tests covering gauge values, counter increments, scanner/notification integration, and full endpoint format

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 446/446
- [x] `update_after_scan()` sets correct gauge values from dict and `UpdateInfo` inputs
- [x] Resolved updates are excluded from `dum_updates_available` counts
- [x] Types that disappear between scans are zeroed out
- [x] `dum_check_errors_total` increments on Docker failure (`DockerException`) and per `ScanWarning`
- [x] `dum_notifications_sent_total` increments per channel; no increment when nothing to notify
- [x] `GET /metrics` returns 200, correct content-type, and all six metric names
- [x] Metric values in endpoint response match the last `update_after_scan()` call