### PR TITLE
[BUG] Fix dedup version comparison to use semver integer ordering

### DIFF
--- a/app/scanner.py
+++ b/app/scanner.py
@@ -20,6 +20,21 @@ from app.health import update_state
 from app.metrics import check_errors_total, update_after_scan
 
 
+def _is_higher_version(candidate: str | None, current: str | None) -> bool:
+    """Return True if candidate > current using semver-aware (integer) comparison.
+
+    Splits both strings by '.' and compares segment-by-segment as integers.
+    Falls back to plain string comparison when any segment is non-numeric
+    (e.g. digest hashes), where string ordering is an acceptable approximation.
+    """
+    c = candidate or ""
+    b = current or ""
+    try:
+        return tuple(int(p) for p in c.split(".")) > tuple(int(p) for p in b.split("."))
+    except ValueError:
+        return c > b
+
+
 def _extract_local_digest(repo_digests: list[str]) -> str | None:
     """Extract the first sha256 digest from a Docker RepoDigests list.
 
@@ -454,7 +469,7 @@ def run_check() -> None:
     _deduped: dict[tuple[str, str, str], UpdateInfo] = {}
     for _u in categorized:
         _key = (_u.container_name, _u.image, _u.update_type)
-        if _key not in _deduped or (_u.new_version or "") > (_deduped[_key].new_version or ""):
+        if _key not in _deduped or _is_higher_version(_u.new_version, _deduped[_key].new_version):
             _deduped[_key] = _u
     categorized = list(_deduped.values())
 

--- a/tests/test_run_check.py
+++ b/tests/test_run_check.py
@@ -7,7 +7,7 @@ import pytest
 from app import config as config_mod
 from app import main as main_mod
 from app.models import UpdateInfo
-from app.scanner import run_check
+from app.scanner import run_check, _is_higher_version
 
 
 def _make_container(name, image_tag, labels, has_image_tags=True):
@@ -558,6 +558,39 @@ class TestRunCheckCooldown:
         assert notified_updates[0].status == "resolved"
 
 
+class TestIsHigherVersion:
+    """Unit tests for the _is_higher_version() semver comparison helper."""
+
+    def test_higher_major_wins(self):
+        assert _is_higher_version("10.0.0", "9.0.0") is True
+
+    def test_lower_major_loses(self):
+        assert _is_higher_version("9.0.0", "10.0.0") is False
+
+    def test_equal_versions_not_higher(self):
+        assert _is_higher_version("1.2.3", "1.2.3") is False
+
+    def test_higher_minor_wins(self):
+        assert _is_higher_version("1.10.0", "1.9.0") is True
+
+    def test_higher_patch_wins(self):
+        assert _is_higher_version("1.0.10", "1.0.9") is True
+
+    def test_none_candidate_is_not_higher(self):
+        assert _is_higher_version(None, "1.0.0") is False
+
+    def test_none_current_makes_any_candidate_higher(self):
+        assert _is_higher_version("1.0.0", None) is True
+
+    def test_both_none_not_higher(self):
+        assert _is_higher_version(None, None) is False
+
+    def test_digest_fallback_uses_string_comparison(self):
+        # Non-numeric segments fall back to string comparison
+        assert _is_higher_version("sha256:bbb", "sha256:aaa") is True
+        assert _is_higher_version("sha256:aaa", "sha256:bbb") is False
+
+
 class TestRunCheckDeduplication:
     """Deduplication of updates with the same (container, image, update_type) key."""
 
@@ -626,6 +659,34 @@ class TestRunCheckDeduplication:
         updates = mock_notify.call_args[0][0]
         assert len(updates) == 1
         assert updates[0].new_version == "1.2.0"
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.mark_notified")
+    @patch("app.scanner.process_scan")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_semver_crossing_digit_boundary(
+        self, mock_docker, mock_token, mock_fetch, mock_scan, mock_mark, mock_notify
+    ):
+        """9.0.0 must not beat 10.0.0 — string '9' > '10' but int 9 < 10."""
+        lower = self._make_update("app", "nginx", "major", "9.0.0")
+        higher = self._make_update("app", "nginx", "major", "10.0.0")
+        # 9.0.0 comes after 10.0.0 in the list — string comparison would pick 9.0.0 wrong
+        mock_scan.return_value = [higher, lower]
+
+        container = _make_container("app", "nginx:1.0.0",
+                                    {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"})
+        client = MagicMock()
+        mock_docker.from_env.return_value = client
+        client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        updates = mock_notify.call_args[0][0]
+        assert len(updates) == 1
+        assert updates[0].new_version == "10.0.0"
 
     @patch("app.scanner.notify")
     @patch("app.scanner.mark_notified")


### PR DESCRIPTION
Closes #120

## Summary
- Replaced plain string `>` comparison in the dedup loop with a semver-aware helper that compares dot-separated segments as integers, fixing the `9.0.0 > 10.0.0` false-positive.
- For non-numeric versions (e.g. digest hashes), the helper falls back to string comparison, which is acceptable per the issue.

## Changes
- `app/scanner.py`: Added `_is_higher_version(candidate, current)` helper; used it in the `run_check()` dedup condition in place of bare string `>`.
- `tests/test_run_check.py`: Added `TestIsHigherVersion` (9 unit tests covering major/minor/patch ordering, None inputs, and digest fallback) and `test_semver_crossing_digit_boundary` in `TestRunCheckDeduplication` to assert `10.0.0` beats `9.0.0`.

## Test plan
- [ ] Full test suite passes (`pytest tests/ -v`)
- [ ] `test_higher_major_wins`: `10.0.0 > 9.0.0` returns True
- [ ] `test_lower_major_loses`: `9.0.0 > 10.0.0` returns False
- [ ] `test_semver_crossing_digit_boundary`: dedup keeps `10.0.0`, not `9.0.0`, when both share the same key
- [ ] `test_digest_fallback_uses_string_comparison`: non-numeric versions fall back gracefully