### PR TITLE
Fix crash on invalid SMTP_PORT/WEB_PORT env vars

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,28 @@
 import os
 import logging
 
+LOG_LEVEL         = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger("dum")
+
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an integer env var, falling back to default with a warning if invalid."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("Invalid %s value %r, falling back to %d", name, raw, default)
+        return default
+
+
 NOTIFY_ENDPOINT   = os.environ.get("NOTIFY_ENDPOINT", "")
 NOTIFY_AUTH_TYPE  = os.environ.get("NOTIFY_AUTH_TYPE", "").lower()
 NOTIFY_AUTH_TOKEN = os.environ.get("NOTIFY_AUTH_TOKEN", "")
@@ -13,25 +35,17 @@ RUN_ON_STARTUP    = os.environ.get("RUN_ON_STARTUP", "true").lower() == "true"
 LABEL_PREFIX      = os.environ.get("LABEL_PREFIX", "docker-update-monitor")
 DRY_RUN           = os.environ.get("DRY_RUN", "false").lower() == "true"
 STATE_DB_PATH     = os.environ.get("STATE_DB_PATH", "/app/data/state.db")
-LOG_LEVEL         = os.environ.get("LOG_LEVEL", "INFO").upper()
 
 SMTP_HOST         = os.environ.get("SMTP_HOST", "")
-SMTP_PORT         = int(os.environ.get("SMTP_PORT", "587"))
+SMTP_PORT         = _int_env("SMTP_PORT", 587)
 SMTP_USERNAME     = os.environ.get("SMTP_USERNAME", "")
 SMTP_PASSWORD     = os.environ.get("SMTP_PASSWORD", "")
 SMTP_FROM         = os.environ.get("SMTP_FROM", "")
 SMTP_TO           = [addr.strip() for addr in os.environ.get("SMTP_TO", "").split(",") if addr.strip()]
 SMTP_TLS          = os.environ.get("SMTP_TLS", "true").lower() == "true"
 
-WEB_PORT          = int(os.environ.get("WEB_PORT", "8080"))
+WEB_PORT          = _int_env("WEB_PORT", 8080)
 DASHBOARD_DATETIME_FORMAT = os.environ.get("DASHBOARD_DATETIME_FORMAT", "%d/%m/%Y %H:%M")
 TZ                = os.environ.get("TZ", "")
 
 UPDATE_COOLDOWN   = os.environ.get("UPDATE_COOLDOWN", "0")
-
-logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
-    format="%(asctime)s  %(levelname)-8s  %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%S",
-)
-log = logging.getLogger("dum")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+"""Tests for env-var parsing in app.config (issue #121)."""
+
+import importlib
+import logging
+
+import pytest
+
+import app.config as config_mod
+
+
+def _reload_config(monkeypatch, **env):
+    """Reload app.config with the given env vars overriding os.environ."""
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    return importlib.reload(config_mod)
+
+
+@pytest.fixture
+def restore_config():
+    """Reload config back to current process env after each test."""
+    yield
+    importlib.reload(config_mod)
+
+
+class TestIntEnvHelper:
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SOME_INT", raising=False)
+        assert config_mod._int_env("SOME_INT", 42) == 42
+
+    def test_returns_default_when_empty(self, monkeypatch):
+        monkeypatch.setenv("SOME_INT", "")
+        assert config_mod._int_env("SOME_INT", 42) == 42
+
+    def test_parses_valid_int(self, monkeypatch):
+        monkeypatch.setenv("SOME_INT", "1234")
+        assert config_mod._int_env("SOME_INT", 42) == 1234
+
+    def test_invalid_int_falls_back_with_warning(self, monkeypatch, caplog):
+        monkeypatch.setenv("SOME_INT", "not_a_number")
+        with caplog.at_level(logging.WARNING, logger="dum"):
+            result = config_mod._int_env("SOME_INT", 42)
+        assert result == 42
+        assert any(
+            "Invalid SOME_INT" in record.getMessage() and "not_a_number" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+class TestSmtpPort:
+    def test_default_when_unset(self, monkeypatch, restore_config):
+        cfg = _reload_config(monkeypatch, SMTP_PORT=None)
+        assert cfg.SMTP_PORT == 587
+
+    def test_valid_value(self, monkeypatch, restore_config):
+        cfg = _reload_config(monkeypatch, SMTP_PORT="2525")
+        assert cfg.SMTP_PORT == 2525
+
+    def test_invalid_value_falls_back(self, monkeypatch, caplog, restore_config):
+        with caplog.at_level(logging.WARNING, logger="dum"):
+            cfg = _reload_config(monkeypatch, SMTP_PORT="not_a_number")
+        assert cfg.SMTP_PORT == 587
+        assert any("SMTP_PORT" in record.getMessage() for record in caplog.records)
+
+    def test_does_not_raise_on_invalid(self, monkeypatch, restore_config):
+        # The bug was a crash at import time; reloading must not raise.
+        _reload_config(monkeypatch, SMTP_PORT="abc")
+
+
+class TestWebPort:
+    def test_default_when_unset(self, monkeypatch, restore_config):
+        cfg = _reload_config(monkeypatch, WEB_PORT=None)
+        assert cfg.WEB_PORT == 8080
+
+    def test_valid_value(self, monkeypatch, restore_config):
+        cfg = _reload_config(monkeypatch, WEB_PORT="9090")
+        assert cfg.WEB_PORT == 9090
+
+    def test_invalid_value_falls_back(self, monkeypatch, caplog, restore_config):
+        with caplog.at_level(logging.WARNING, logger="dum"):
+            cfg = _reload_config(monkeypatch, WEB_PORT="oops")
+        assert cfg.WEB_PORT == 8080
+        assert any("WEB_PORT" in record.getMessage() for record in caplog.records)
+
+    def test_does_not_raise_on_invalid(self, monkeypatch, restore_config):
+        _reload_config(monkeypatch, WEB_PORT="oops")


### PR DESCRIPTION
## Summary
- Non-numeric `SMTP_PORT` or `WEB_PORT` (e.g. `SMTP_PORT=abc`) no longer crashes the app at config-import time.
- Bad values now fall back to the documented defaults (587 / 8080) and emit a warning log naming the offending var and value.

## Changes
- `app/config.py`: introduced `_int_env(name, default)` that wraps `int()` parsing in a try/except, logs a warning on failure, and returns the default. `SMTP_PORT` and `WEB_PORT` now use it. Moved `logging.basicConfig` to the top of the module so the warning is actually emitted (previously logging was configured after the parsing that would crash).
- `tests/test_config.py`: new test module reloading `app.config` under `monkeypatch`-controlled env to cover unset / valid / invalid / empty cases for the helper, `SMTP_PORT`, and `WEB_PORT`, including assertions that the warning is logged and that import no longer raises.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — verified locally: 471 passed.
- [x] Setting `SMTP_PORT=not_a_number` reloads config without raising and produces a `dum`-logger warning naming `SMTP_PORT` and the bad value; `SMTP_PORT` resolves to 587.
- [x] Same scenario for `WEB_PORT=oops` → resolves to 8080 with a warning.
- [x] Valid numeric values (`SMTP_PORT=2525`, `WEB_PORT=9090`) still parse to the integer as before.

Closes #121