### PR TITLE
fix: narrow broad except Exception to specific types in scanner and webhook

### DIFF
--- a/app/notifications/webhook.py
+++ b/app/notifications/webhook.py
@@ -1,6 +1,8 @@
 import json
 from dataclasses import asdict
 
+import requests
+
 import app.config as _config
 import app.http as _http
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
@@ -63,5 +65,5 @@ def notify(
         )
         resp.raise_for_status()
         _config.log.info(f"Notified endpoint with {len(updates)} update(s)  →  HTTP {resp.status_code}")
-    except Exception as exc:
+    except requests.RequestException as exc:
         _config.log.error(f"Failed to notify endpoint: {exc}")

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta, timezone
 _GIT_HASH_RE = re.compile(r"sha-[a-f0-9]{7,}")
 
 import docker
-from docker.errors import DockerException
+import requests
+from docker.errors import APIError as DockerAPIError, DockerException
 
 import app.config as _config
 from app.cooldown import parse_cooldown
@@ -274,7 +275,7 @@ def run_check() -> None:
                                     f"    Platform digest unchanged for"
                                     f" {container_os}/{container_arch} ({local_digest[:19]})"
                                 )
-                    except Exception as exc:
+                    except (DockerAPIError, KeyError, requests.RequestException) as exc:
                         _config.log.debug(f"    Could not check platform digest: {exc}")
 
                     if not platform_match:

--- a/tests/test_digest_detection.py
+++ b/tests/test_digest_detection.py
@@ -862,3 +862,104 @@ class TestFetchPlatformDigest:
             )
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Platform digest exception handling — narrowed from broad Exception
+# ---------------------------------------------------------------------------
+
+class TestPlatformDigestExceptionHandling:
+    """Verify that only specific exceptions are caught in the platform digest block."""
+
+    def _setup_digest_mismatch(self, mock_docker, local_digest="sha256:aabbcc", remote_digest="sha256:ddeeff"):
+        """Configure a mock docker client where local != remote digest, triggering platform check."""
+        container = MagicMock()
+        container.name = "myapp"
+        container.labels = {"docker-update-monitor.mode": "digest"}
+        container.image.tags = ["nginx:latest"]
+        container.attrs = {"Config": {"Image": "nginx:latest"}}
+        container.image.attrs = {
+            "RepoDigests": [f"nginx@{local_digest}"],
+            "Os": "linux",
+            "Architecture": "amd64",
+        }
+
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [container]
+        return container, local_digest, remote_digest
+
+    @patch("app.scanner.fetch_platform_digest")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_requests_exception_is_caught(self, mock_docker, _token, mock_fetch_digest, mock_platform_digest):
+        """requests.RequestException during platform digest check is caught and logged."""
+        import requests
+
+        container, local, remote = self._setup_digest_mismatch(mock_docker)
+        mock_fetch_digest.return_value = remote
+        mock_platform_digest.side_effect = requests.ConnectionError("network down")
+
+        with patch("app.scanner.notify") as mock_notify, \
+             patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "DOCKERHUB_USER", ""), \
+             patch.object(config_mod, "DOCKERHUB_PASS", ""):
+            run_check()
+
+        mock_notify.assert_called_once()
+
+    @patch("app.scanner.fetch_platform_digest")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_key_error_is_caught(self, mock_docker, _token, mock_fetch_digest, mock_platform_digest):
+        """KeyError during platform digest check is caught and logged."""
+        container, local, remote = self._setup_digest_mismatch(mock_docker)
+        mock_fetch_digest.return_value = remote
+        mock_platform_digest.side_effect = KeyError("missing_key")
+
+        with patch("app.scanner.notify") as mock_notify, \
+             patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "DOCKERHUB_USER", ""), \
+             patch.object(config_mod, "DOCKERHUB_PASS", ""):
+            run_check()
+
+        mock_notify.assert_called_once()
+
+    @patch("app.scanner.fetch_platform_digest")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_docker_api_error_is_caught(self, mock_docker, _token, mock_fetch_digest, mock_platform_digest):
+        """docker.errors.APIError during platform digest check is caught and logged."""
+        import docker as docker_mod
+
+        container, local, remote = self._setup_digest_mismatch(mock_docker)
+        mock_fetch_digest.return_value = remote
+        mock_platform_digest.side_effect = docker_mod.errors.APIError("docker error")
+
+        with patch("app.scanner.notify") as mock_notify, \
+             patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "DOCKERHUB_USER", ""), \
+             patch.object(config_mod, "DOCKERHUB_PASS", ""):
+            run_check()
+
+        mock_notify.assert_called_once()
+
+    @patch("app.scanner.fetch_platform_digest")
+    @patch("app.scanner.fetch_digest")
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_programming_error_propagates(self, mock_docker, _token, mock_fetch_digest, mock_platform_digest):
+        """Programming errors (e.g. AttributeError) must not be swallowed."""
+        container, local, remote = self._setup_digest_mismatch(mock_docker)
+        mock_fetch_digest.return_value = remote
+        mock_platform_digest.side_effect = AttributeError("bad attribute")
+
+        with patch("app.scanner.notify"), \
+             patch.object(config_mod, "GITHUB_TOKEN", ""), \
+             patch.object(config_mod, "DOCKERHUB_USER", ""), \
+             patch.object(config_mod, "DOCKERHUB_PASS", ""):
+            with pytest.raises(AttributeError, match="bad attribute"):
+                run_check()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -115,13 +115,14 @@ class TestNotifySuccessfulPost:
 
 
 class TestNotifyFailedPost:
-    """Failed POST logs error but does not raise."""
+    """Failed POST logs error but does not raise for network errors."""
 
     @patch.object(http_mod, "http_session")
     def test_failed_post_logs_error(self, mock_session, caplog):
         import logging
+        import requests
 
-        mock_session.post.side_effect = Exception("Connection refused")
+        mock_session.post.side_effect = requests.ConnectionError("Connection refused")
 
         with patch.object(config_mod, "DRY_RUN", False), \
              patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
@@ -135,7 +136,9 @@ class TestNotifyFailedPost:
 
     @patch.object(http_mod, "http_session")
     def test_failed_post_does_not_raise(self, mock_session):
-        mock_session.post.side_effect = Exception("timeout")
+        import requests
+
+        mock_session.post.side_effect = requests.Timeout("timeout")
 
         with patch.object(config_mod, "DRY_RUN", False), \
              patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
@@ -143,6 +146,18 @@ class TestNotifyFailedPost:
              patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
             # Should not raise
             notify([_make_update()])
+
+    @patch.object(http_mod, "http_session")
+    def test_programming_error_propagates(self, mock_session):
+        """Non-network exceptions (programming bugs) must not be swallowed."""
+        mock_session.post.side_effect = AttributeError("bad attribute")
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            with pytest.raises(AttributeError, match="bad attribute"):
+                notify([_make_update()])
 
 
 class TestNotifyEmptyList:


### PR DESCRIPTION
## Summary
- `app/scanner.py`: replaced `except Exception` in the platform digest validation block with `except (DockerAPIError, KeyError, requests.RequestException)` — the three transient failure modes that are legitimately expected there
- `app/notifications/webhook.py`: replaced `except Exception` in the webhook POST block with `except requests.RequestException` — the only transient failure mode relevant for HTTP calls
- Programming errors (e.g. `AttributeError`, `TypeError`) now propagate instead of being silently logged and swallowed

## Changes
- `app/scanner.py`: added `import requests` and `APIError as DockerAPIError`; narrowed exception clause in platform digest check
- `app/notifications/webhook.py`: added `import requests`; narrowed exception clause in endpoint POST block
- `tests/test_digest_detection.py`: added `TestPlatformDigestExceptionHandling` — four tests covering each caught type and verifying `AttributeError` propagates
- `tests/test_notifications.py`: updated existing tests to use `requests.ConnectionError`/`requests.Timeout` instead of bare `Exception`; added `test_programming_error_propagates`

## Test plan
- [x] Full test suite passes (`pytest tests/ -v` — 480 passed)
- [x] `requests.ConnectionError`, `KeyError`, and `docker.errors.APIError` are caught in scanner platform digest block
- [x] `requests.RequestException` is caught in webhook POST block
- [x] `AttributeError` (programming error) propagates in both scanner and webhook