### PR TITLE
Fix type annotation for container_cooldowns: object → timedelta (#125)

### DIFF
--- a/app/scanner.py
+++ b/app/scanner.py
@@ -127,7 +127,7 @@ def run_check() -> None:
         skipped_containers: list[dict] = []
         monitored_versions: dict[tuple[str, str], tuple[str, str]] = {}
         running_digests: dict[tuple[str, str], list[str]] = {}
-        container_cooldowns: dict[str, object] = {}  # container_name → timedelta
+        container_cooldowns: dict[str, timedelta] = {}
         monitored_count = 0
 
         for container in containers:


### PR DESCRIPTION
## Summary
- Fixes incorrect type annotation on `container_cooldowns` dict in `app/scanner.py`
- Restores type-checker visibility for all downstream uses, including the `timedelta` comparison on line ~490

## Changes
- `app/scanner.py`: Changed `dict[str, object]` to `dict[str, timedelta]` — `object` was too broad and prevented mypy/pyright from validating the cooldown comparison; `timedelta` is already imported and is the only type ever stored here

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`)
- [x] No functional behaviour changed — purely a type annotation correction