### PR TITLE
docs: explain why warnings/skipped_containers are excluded from /health response

### DIFF
--- a/app/health.py
+++ b/app/health.py
@@ -43,6 +43,8 @@ def _build_response() -> tuple[int, dict]:
         last_check = _state["last_check"]
         next_check = _state["next_check"]
         containers_monitored = _state["containers_monitored"]
+        # warnings and skipped_containers are intentionally excluded from the
+        # health endpoint to keep it lightweight. The dashboard serves the full state.
 
     body = {
         "status": "ok",


### PR DESCRIPTION
## Summary
- Adds an inline comment to `_build_response()` in `app/health.py` explaining the intentional omission of `warnings` and `skipped_containers` from the `/health` endpoint
- Prevents future contributors from mistakenly "fixing" the missing fields and bloating the health check response

## Changes
- `app/health.py`: Added two-line comment inside `_build_response()` clarifying that `warnings` and `skipped_containers` are excluded by design to keep the health endpoint lightweight, with the dashboard serving the full state

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 480 passed

Closes #128