### PR TITLE
Remove dead 503 branch from healthcheck.py; /health is liveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Then open `http://<your-host>:8080` in a browser.
 | Method | Path           | Description                                      |
 | ------ | -------------- | ------------------------------------------------ |
 | `GET`  | `/`            | Dashboard page (HTML)                            |
-| `GET`  | `/health`      | Health check (JSON) — used by Docker HEALTHCHECK |
+| `GET`  | `/health`      | Liveness check (JSON) — used by Docker HEALTHCHECK. Always `200` while the server is up; body `status` is `"starting"` until the first scan completes, then `"ok"`. |
 | `GET`  | `/api/updates` | All updates with status as JSON array            |
 | `POST` | `/api/scan`    | Trigger immediate scan, returns 202 Accepted     |
 | `GET`  | `/metrics`     | Prometheus metrics (text/plain)                  |

--- a/app/healthcheck.py
+++ b/app/healthcheck.py
@@ -1,11 +1,8 @@
 """Health check script for Docker HEALTHCHECK directive."""
 import sys
 import urllib.request
-import urllib.error
 
 try:
     urllib.request.urlopen("http://localhost:8080/health")
-except urllib.error.HTTPError:
-    pass  # 503 is fine — server is up, just no scan completed yet
 except Exception:
     sys.exit(1)

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -22,7 +22,7 @@ class TestHealthcheck:
         mock_urlopen.assert_called_with("http://localhost:8080/health")
 
     @patch("urllib.request.urlopen")
-    def test_http_error_exits_normally(self, mock_urlopen):
+    def test_http_error_exits_with_1(self, mock_urlopen):
         mock_urlopen.side_effect = urllib.error.HTTPError(
             url="http://localhost:8080/health",
             code=503,
@@ -30,8 +30,9 @@ class TestHealthcheck:
             hdrs={},
             fp=None,
         )
-        # HTTPError is swallowed (503 means server is up)
-        self._run_healthcheck()
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_healthcheck()
+        assert exc_info.value.code == 1
 
     @patch("urllib.request.urlopen")
     def test_connection_error_exits_with_1(self, mock_urlopen):


### PR DESCRIPTION
## Summary
- Resolves #139 by taking the "always 200" path: `/health` is a liveness signal, not a readiness gate.
- "starting" (no scan yet) and "waiting for next scan" are both healthy states — only emit non-2xx when the container is actually in trouble.
- The `except urllib.error.HTTPError: pass` branch in `app/healthcheck.py` was therefore dead and is removed; any non-2xx now exits 1.

## Changes
- `app/healthcheck.py`: drop the `except HTTPError: pass` branch and the now-unused `import urllib.error`. Any HTTP error response falls through to `except Exception: sys.exit(1)`.
- `tests/test_healthcheck.py`: rename `test_http_error_exits_normally` → `test_http_error_exits_with_1` and assert `SystemExit(1)` on `HTTPError(503)`, reflecting the new contract.
- `README.md`: relabel the `/health` row as a liveness check and spell out the body-`status` transitions (`"starting"` → `"ok"`) so the always-200 behavior is documented.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 480 passed.
- [x] `HTTPError` returned by `urlopen` now causes the healthcheck script to exit 1 (`test_http_error_exits_with_1`).
- [x] Successful 200 response from `/health` still exits 0 (`test_successful_request_exits_normally`).
- [x] Connection/timeout/URL errors still exit 1 (existing tests).