### PR TITLE
Fix _resolve_digest_to_tag returning current_tag as new version (#140)

### DIFF
--- a/app/scanner.py
+++ b/app/scanner.py
@@ -64,7 +64,7 @@ def _resolve_digest_to_tag(
     covers git-hash tags (e.g. sha-675e77e) used by GHCR and Docker Hub.
     The pattern defines what is "versioned"; everything else is treated as rolling.
     """
-    matching_tags = [t for t in all_tags if re.fullmatch(pattern, t)]
+    matching_tags = [t for t in all_tags if t != current_tag and re.fullmatch(pattern, t)]
     for tag in matching_tags:
         tag_digest = fetch_digest(
             image_name, tag,

--- a/tests/test_digest_detection.py
+++ b/tests/test_digest_detection.py
@@ -166,6 +166,20 @@ class TestDigestVersionResolution:
         assert result is None
 
     @patch("app.scanner.fetch_digest")
+    def test_resolve_digest_excludes_current_tag_from_pattern_matches(self, mock_fetch_digest):
+        """Regression: pattern phase must skip current_tag, mirroring the fallback phase."""
+        mock_fetch_digest.return_value = "sha256:target"
+
+        result = _resolve_digest_to_tag(
+            "myimage",
+            "sha256:target",
+            ["1.2.3"],
+            r"^(\d+)\.(\d+)\.(\d+)$",
+            current_tag="1.2.3",
+        )
+        assert result is None
+
+    @patch("app.scanner.fetch_digest")
     def test_resolve_digest_prefers_git_hash_over_other_rolling_tags(self, mock_fetch_digest):
         def digest_side_effect(image, tag, *args, **kwargs):
             if tag in ("latest", "sha-abcdef1"):


### PR DESCRIPTION
## Summary
- Fix bug where `_resolve_digest_to_tag` could report `current_tag` as the resolved "new" tag, producing spurious `current → current` update notifications.
- Pattern-matching phase now excludes `current_tag`, symmetric with the existing fallback phase.

## Changes
- `app/scanner.py`: in `_resolve_digest_to_tag`, filter `current_tag` out of `matching_tags` (mirrors the fallback at lines 79-82).
- `tests/test_digest_detection.py`: add regression test `test_resolve_digest_excludes_current_tag_from_pattern_matches` covering the case where the only versioned tag is `current_tag` and its digest equals the target.

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`)
- [x] New regression test asserts the resolver returns `None` when the only pattern-matching tag is `current_tag`

Closes #140