### PR TITLE
Release _state_lock before save_last_check SQLite write

### DIFF
--- a/app/health.py
+++ b/app/health.py
@@ -23,11 +23,12 @@ def update_state(*, last_check: datetime | None = None, next_check: datetime | N
                  containers_monitored: int | None = None,
                  warnings: list[dict] | None = None,
                  skipped_containers: list[dict] | None = None) -> None:
+    iso_to_persist: str | None = None
     with _state_lock:
         if last_check is not None:
             iso = last_check.isoformat().replace("+00:00", "Z")
             _state["last_check"] = iso
-            save_last_check(iso)
+            iso_to_persist = iso
         if next_check is not None:
             _state["next_check"] = next_check.isoformat().replace("+00:00", "Z")
         if containers_monitored is not None:
@@ -36,6 +37,8 @@ def update_state(*, last_check: datetime | None = None, next_check: datetime | N
             _state["warnings"] = list(warnings)
         if skipped_containers is not None:
             _state["skipped_containers"] = list(skipped_containers)
+    if iso_to_persist is not None:
+        save_last_check(iso_to_persist)
 
 
 def _build_response() -> tuple[int, dict]:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -85,6 +85,27 @@ class TestHealthResponse:
         with health._state_lock:
             assert health._state["skipped_containers"] == skipped
 
+    def test_update_state_releases_lock_before_save_last_check(self):
+        """save_last_check must be called outside _state_lock so DB I/O does not stall readers."""
+        lock_held_during_save: list[bool] = []
+
+        def fake_save(iso):
+            lock_held_during_save.append(health._state_lock.locked())
+
+        now = datetime(2026, 4, 28, 3, 0, 0, tzinfo=timezone.utc)
+        with patch("app.health.save_last_check", side_effect=fake_save):
+            health.update_state(last_check=now)
+
+        assert lock_held_during_save == [False], (
+            "save_last_check must be called with _state_lock released"
+        )
+
+    def test_update_state_does_not_persist_when_last_check_absent(self):
+        """save_last_check is only invoked when last_check is provided."""
+        with patch("app.health.save_last_check") as mock_save:
+            health.update_state(containers_monitored=3)
+        mock_save.assert_not_called()
+
 
 class TestHealthEndpoint:
     """Integration tests hitting the actual HTTP server."""


### PR DESCRIPTION
## Summary
- Fixes #141: `update_state` no longer holds `_state_lock` across the `save_last_check` SQLite write, so scanner-side disk latency stops stalling `/health`, `/`, and `/api/last-scan`.
- The lock now protects only the in-memory `_state` dict, matching the fix sketch in the issue.

## Changes
- `app/health.py`: capture the ISO timestamp into a local under the lock, release the lock, then call `save_last_check` outside the critical section.
- `tests/test_health.py`: add `test_update_state_releases_lock_before_save_last_check` (patches `save_last_check` and asserts `_state_lock.locked()` is False at call time — regression guard against re-tightening the lock) and `test_update_state_does_not_persist_when_last_check_absent` (DB write skipped when `last_check` isn't provided).

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 483 passed
- [x] New `test_update_state_releases_lock_before_save_last_check` asserts `save_last_check` runs with the lock released
- [x] Manual: under a slow disk (e.g. NFS) confirm `/health` latency no longer correlates with scanner writes — cannot be exercised in CI