### PR TITLE
Base64-encode basic auth token in webhook Authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ could be matched to the new digest) or the raw registry digest (`sha256:…`).
 | ------------------- | --------- | ------------------------------------------------ |
 | `NOTIFY_ENDPOINT`   | _(empty)_ | Webhook URL to POST updates to                   |
 | `NOTIFY_AUTH_TYPE`  | _(empty)_ | Auth type: `bearer`, `basic`, or empty (no auth) |
-| `NOTIFY_AUTH_TOKEN` | _(empty)_ | Token/credentials for the `Authorization` header |
+| `NOTIFY_AUTH_TOKEN` | _(empty)_ | Credentials for the `Authorization` header. For `bearer`, the raw token. For `basic`, `user:pass` (base64-encoded automatically). |
 
 ### Email channel (SMTP)
 

--- a/app/notifications/webhook.py
+++ b/app/notifications/webhook.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from dataclasses import asdict
 
@@ -52,7 +53,8 @@ def notify(
     if _config.NOTIFY_AUTH_TYPE == "bearer" and _config.NOTIFY_AUTH_TOKEN:
         headers["Authorization"] = f"Bearer {_config.NOTIFY_AUTH_TOKEN}"
     elif _config.NOTIFY_AUTH_TYPE == "basic" and _config.NOTIFY_AUTH_TOKEN:
-        headers["Authorization"] = f"Basic {_config.NOTIFY_AUTH_TOKEN}"
+        encoded = base64.b64encode(_config.NOTIFY_AUTH_TOKEN.encode("utf-8")).decode("ascii")
+        headers["Authorization"] = f"Basic {encoded}"
     elif _config.NOTIFY_AUTH_TYPE and _config.NOTIFY_AUTH_TYPE not in ("bearer", "basic"):
         _config.log.warning(f"Unknown NOTIFY_AUTH_TYPE '{_config.NOTIFY_AUTH_TYPE}' — sending without authentication")
 

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,5 +1,6 @@
 """Tests for webhook authentication support (NOTIFY_AUTH_TYPE / NOTIFY_AUTH_TOKEN)."""
 
+import base64
 from unittest.mock import MagicMock, patch
 
 from app import config as config_mod
@@ -60,10 +61,10 @@ class TestWebhookAuthBearer:
 
 
 class TestWebhookAuthBasic:
-    """Basic authentication."""
+    """Basic authentication — token is supplied as `user:pass` and base64-encoded by the app."""
 
     @patch.object(http_mod, "http_session")
-    def test_basic_auth_sends_authorization_header(self, mock_session):
+    def test_basic_auth_base64_encodes_user_pass(self, mock_session):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
@@ -72,12 +73,52 @@ class TestWebhookAuthBasic:
         with patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
              patch.object(config_mod, "DRY_RUN", False), \
              patch.object(config_mod, "NOTIFY_AUTH_TYPE", "basic"), \
-             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", "dXNlcjpwYXNz"):
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", "user:pass"):
             notify([_make_update()])
 
         call_kwargs = mock_session.post.call_args
         headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
         assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+    @patch.object(http_mod, "http_session")
+    def test_basic_auth_encodes_special_characters(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        token = "admin:p@ss w0rd!"
+        expected = base64.b64encode(token.encode("utf-8")).decode("ascii")
+
+        with patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", "basic"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", token):
+            notify([_make_update()])
+
+        call_kwargs = mock_session.post.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert headers["Authorization"] == f"Basic {expected}"
+
+    @patch.object(http_mod, "http_session")
+    def test_basic_auth_encodes_utf8(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        token = "café:naïve"
+        expected = base64.b64encode(token.encode("utf-8")).decode("ascii")
+
+        with patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", "basic"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", token):
+            notify([_make_update()])
+
+        call_kwargs = mock_session.post.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert headers["Authorization"] == f"Basic {expected}"
 
 
 class TestWebhookAuthNone:


### PR DESCRIPTION
## Summary
- Webhook Basic auth header was emitted as `Basic <raw-token>`, producing a malformed header when users supplied `user:pass` as the README implied.
- Encode `NOTIFY_AUTH_TOKEN` with base64 in code so the documented `user:pass` form actually works.

## Changes
- `app/notifications/webhook.py`: base64-encode `NOTIFY_AUTH_TOKEN` (UTF-8) before composing the `Basic` header. Bearer path unchanged.
- `README.md`: clarify that `NOTIFY_AUTH_TOKEN` is `user:pass` for `basic` (encoded automatically), raw token for `bearer`.
- `tests/test_webhook_auth.py`: replace the old test that asserted the pass-through (broken) behavior with three tests covering plain `user:pass`, special characters, and UTF-8 credentials.

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 485 passed
- [x] `Basic user:pass` produces `Authorization: Basic dXNlcjpwYXNz`
- [x] Special characters and UTF-8 in credentials are encoded correctly
- [x] Bearer / no-auth / invalid-type paths are unchanged

Fixes #142