### PR TITLE
Remove dead _HealthHandler and start_health_server

### DIFF
--- a/app/health.py
+++ b/app/health.py
@@ -1,10 +1,7 @@
-import json
 import threading
 import time
 from datetime import datetime, timezone
-from http.server import HTTPServer, BaseHTTPRequestHandler
 
-import app.config as _config
 from app.state import save_last_check
 
 _start_time = time.monotonic()
@@ -62,30 +59,3 @@ def _build_response() -> tuple[int, dict]:
         body["note"] = "waiting for first scan to complete"
 
     return 200, body
-
-
-class _HealthHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        if self.path == "/health":
-            status_code, body = _build_response()
-            payload = json.dumps(body).encode()
-            self.send_response(status_code)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(payload)))
-            self.end_headers()
-            self.wfile.write(payload)
-        else:
-            self.send_response(404)
-            self.end_headers()
-
-    def log_message(self, format, *args):
-        pass  # suppress access logs
-
-
-def start_health_server() -> threading.Thread:
-    server = HTTPServer(("0.0.0.0", _config.WEB_PORT), _HealthHandler)
-    server.allow_reuse_address = True
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    _config.log.info(f"Health endpoint listening on port {_config.WEB_PORT}")
-    return thread

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,8 +1,5 @@
 """Tests for the /health endpoint."""
 
-import json
-import time
-import urllib.request
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -19,21 +16,6 @@ def _reset_health_state():
         health._state["next_check"] = None
         health._state["containers_monitored"] = 0
     yield
-
-
-@pytest.fixture()
-def health_server():
-    """Start the health server on a random port for testing."""
-    from http.server import HTTPServer
-
-    server = HTTPServer(("127.0.0.1", 0), health._HealthHandler)
-    port = server.server_address[1]
-    import threading
-
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    yield port
-    server.shutdown()
 
 
 class TestHealthResponse:
@@ -105,36 +87,3 @@ class TestHealthResponse:
         with patch("app.health.save_last_check") as mock_save:
             health.update_state(containers_monitored=3)
         mock_save.assert_not_called()
-
-
-class TestHealthEndpoint:
-    """Integration tests hitting the actual HTTP server."""
-
-    def test_health_returns_200_starting_no_check(self, health_server):
-        url = f"http://127.0.0.1:{health_server}/health"
-        with urllib.request.urlopen(url) as resp:
-            assert resp.status == 200
-            body = json.loads(resp.read())
-            assert body["status"] == "starting"
-            assert "waiting for first scan" in body["note"]
-
-    def test_health_returns_200_after_check(self, health_server):
-        now = datetime(2026, 4, 28, 3, 0, 0, tzinfo=timezone.utc)
-        next_t = datetime(2026, 5, 5, 3, 0, 0, tzinfo=timezone.utc)
-        health.update_state(last_check=now, next_check=next_t, containers_monitored=7)
-
-        url = f"http://127.0.0.1:{health_server}/health"
-        with urllib.request.urlopen(url) as resp:
-            assert resp.status == 200
-            body = json.loads(resp.read())
-            assert body["status"] == "ok"
-            assert body["containers_monitored"] == 7
-
-    def test_unknown_path_returns_404(self, health_server):
-        url = f"http://127.0.0.1:{health_server}/unknown"
-        req = urllib.request.Request(url)
-        try:
-            urllib.request.urlopen(req)
-            assert False, "Expected HTTPError"
-        except urllib.error.HTTPError as e:
-            assert e.code == 404


### PR DESCRIPTION
## Summary
- Production `/health` is served by Flask in `app/dashboard.py`; the `BaseHTTPRequestHandler`-based server in `app/health.py` was never wired up and only existed to satisfy its own tests.
- Removing the dead code (and the tests that exercised it) leaves the live response builder `_build_response()` and its unit tests in place — no behavior change.

## Changes
- `app/health.py`: deleted `_HealthHandler` class, `start_health_server()`, and the now-unused imports (`json`, `HTTPServer`, `BaseHTTPRequestHandler`, `app.config`).
- `tests/test_health.py`: removed the `health_server` fixture and `TestHealthEndpoint` class. `TestHealthResponse` (which targets `_build_response()` directly) is retained.

Closes #143

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 482 passed
- [x] `_build_response` coverage still present via `TestHealthResponse`
- [x] Manual: hit `/health` on a running container and confirm Flask route still responds (production path unchanged)