### PR TITLE
Split notifications counter into attempted and sent (fix #144)

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -28,9 +28,15 @@ last_check_timestamp_seconds = Gauge(
     "Unix timestamp of last completed check",
 )
 
+notifications_attempted_total = Counter(
+    "dum_notifications_attempted_total",
+    "Total notifications attempted (delivery tried) by channel",
+    ["channel"],
+)
+
 notifications_sent_total = Counter(
     "dum_notifications_sent_total",
-    "Total notifications sent by channel",
+    "Total notifications successfully delivered by channel",
     ["channel"],
 )
 

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -2,7 +2,17 @@ import app.config as _config
 from app.models import UpdateInfo, RegexMismatch, ScanWarning
 from app.notifications.webhook import notify as webhook_notify
 from app.notifications.email import notify as email_notify
-from app.metrics import notifications_sent_total
+from app.metrics import notifications_attempted_total, notifications_sent_total
+
+
+def _record(channel: str, result: bool | None) -> None:
+    """Update attempted/sent counters based on a notifier return value."""
+    if result is None:
+        # Notifier skipped (no payload, dry-run, missing config) — no attempt made.
+        return
+    notifications_attempted_total.labels(channel=channel).inc()
+    if result:
+        notifications_sent_total.labels(channel=channel).inc()
 
 
 def dispatch(
@@ -17,10 +27,10 @@ def dispatch(
 
     for channel in _config.NOTIFY_CHANNELS:
         if channel == "webhook":
-            webhook_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
-            notifications_sent_total.labels(channel="webhook").inc()
+            result = webhook_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
+            _record("webhook", result)
         elif channel == "email":
-            email_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
-            notifications_sent_total.labels(channel="email").inc()
+            result = email_notify(updates, mismatches=mismatches or [], warnings=warnings or [])
+            _record("email", result)
         else:
             _config.log.warning(f"Unknown notification channel '{channel}' — skipping")

--- a/app/notifications/email.py
+++ b/app/notifications/email.py
@@ -197,13 +197,19 @@ def notify(
     *,
     mismatches: list[RegexMismatch] | None = None,
     warnings: list[ScanWarning] | None = None,
-) -> None:
+) -> bool | None:
+    """Send email notification.
+
+    Returns True on successful delivery, False on a delivery attempt that
+    failed (e.g. SMTP error), and None when no delivery was attempted (empty
+    payload, missing SMTP configuration).
+    """
     if not updates and not mismatches and not warnings:
-        return
+        return None
 
     if not _config.SMTP_HOST or not _config.SMTP_FROM or not _config.SMTP_TO:
         _config.log.warning("SMTP not fully configured (SMTP_HOST, SMTP_FROM, SMTP_TO required) — skipping email notification.")
-        return
+        return None
 
     new, known, resolved = _split_by_status(updates)
     total = len(new) + len(known) + len(resolved)
@@ -234,6 +240,9 @@ def notify(
             if _config.SMTP_USERNAME and _config.SMTP_PASSWORD:
                 server.login(_config.SMTP_USERNAME, _config.SMTP_PASSWORD)
             server.sendmail(_config.SMTP_FROM, _config.SMTP_TO, msg.as_string())
-        _config.log.info(f"Email sent to {', '.join(_config.SMTP_TO)} with {len(updates)} update(s)")
     except Exception as exc:
         _config.log.error(f"Failed to send email notification: {exc}")
+        return False
+
+    _config.log.info(f"Email sent to {', '.join(_config.SMTP_TO)} with {len(updates)} update(s)")
+    return True

--- a/app/notifications/webhook.py
+++ b/app/notifications/webhook.py
@@ -34,20 +34,26 @@ def notify(
     *,
     mismatches: list[RegexMismatch] | None = None,
     warnings: list[ScanWarning] | None = None,
-) -> None:
+) -> bool | None:
+    """Send webhook notification.
+
+    Returns True on successful delivery, False on a delivery attempt that
+    failed (e.g. network error, non-2xx response), and None when no delivery
+    was attempted (empty payload, DRY_RUN, missing endpoint).
+    """
     if not updates and not mismatches and not warnings:
-        return
+        return None
 
     payload = _build_payload(updates, mismatches or [], warnings or [])
 
     if _config.DRY_RUN:
         _config.log.info("DRY_RUN — would POST:\n" + json.dumps(payload, indent=2))
-        return
+        return None
 
     if not _config.NOTIFY_ENDPOINT:
         _config.log.warning("No NOTIFY_ENDPOINT set; skipping notification.")
         _config.log.info("Updates found:\n" + json.dumps(payload, indent=2))
-        return
+        return None
 
     headers = {"Content-Type": "application/json"}
     if _config.NOTIFY_AUTH_TYPE == "bearer" and _config.NOTIFY_AUTH_TOKEN:
@@ -66,6 +72,9 @@ def notify(
             timeout=15,
         )
         resp.raise_for_status()
-        _config.log.info(f"Notified endpoint with {len(updates)} update(s)  →  HTTP {resp.status_code}")
     except requests.RequestException as exc:
         _config.log.error(f"Failed to notify endpoint: {exc}")
+        return False
+
+    _config.log.info(f"Notified endpoint with {len(updates)} update(s)  →  HTTP {resp.status_code}")
+    return True

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -233,6 +233,43 @@ class TestEmailNotify:
         assert "3_image_updates" in raw_email  # Q-encoded subject
 
 
+class TestEmailNotifyReturnValue:
+    """email_notify returns True on success, False on failure, None when not attempted."""
+
+    @patch("app.notifications.email.smtplib.SMTP")
+    def test_returns_true_on_success(self, mock_smtp_cls):
+        mock_smtp_cls.return_value = MagicMock()
+        with patch.object(config_mod, "SMTP_HOST", "smtp.example.com"), \
+             patch.object(config_mod, "SMTP_PORT", 587), \
+             patch.object(config_mod, "SMTP_FROM", "from@example.com"), \
+             patch.object(config_mod, "SMTP_TO", ["to@example.com"]), \
+             patch.object(config_mod, "SMTP_TLS", False), \
+             patch.object(config_mod, "SMTP_USERNAME", ""), \
+             patch.object(config_mod, "SMTP_PASSWORD", ""):
+            assert email_notify([_make_update()]) is True
+
+    @patch("app.notifications.email.smtplib.SMTP")
+    def test_returns_false_on_smtp_error(self, mock_smtp_cls):
+        mock_smtp_cls.return_value.sendmail.side_effect = Exception("smtp boom")
+        with patch.object(config_mod, "SMTP_HOST", "smtp.example.com"), \
+             patch.object(config_mod, "SMTP_PORT", 587), \
+             patch.object(config_mod, "SMTP_FROM", "from@example.com"), \
+             patch.object(config_mod, "SMTP_TO", ["to@example.com"]), \
+             patch.object(config_mod, "SMTP_TLS", False), \
+             patch.object(config_mod, "SMTP_USERNAME", ""), \
+             patch.object(config_mod, "SMTP_PASSWORD", ""):
+            assert email_notify([_make_update()]) is False
+
+    def test_returns_none_when_smtp_unconfigured(self):
+        with patch.object(config_mod, "SMTP_HOST", ""), \
+             patch.object(config_mod, "SMTP_FROM", ""), \
+             patch.object(config_mod, "SMTP_TO", []):
+            assert email_notify([_make_update()]) is None
+
+    def test_returns_none_when_nothing_to_send(self):
+        assert email_notify([]) is None
+
+
 class TestNotifyChannelsDispatch:
     """Tests for the channel dispatcher."""
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -10,6 +10,7 @@ from app.metrics import (
     check_duration_seconds,
     check_errors_total,
     last_check_timestamp_seconds,
+    notifications_attempted_total,
     notifications_sent_total,
     update_after_scan,
 )
@@ -142,34 +143,76 @@ class TestCheckErrorsCounter:
 
 
 class TestNotificationsSentCounter:
-    """notifications_sent_total increments per channel dispatch."""
+    """notifications_sent_total increments only on successful delivery."""
 
-    def test_increments_webhook_channel(self):
-        before = notifications_sent_total.labels(channel="webhook")._value.get()
-        with patch("app.notifications.webhook_notify"), \
+    def test_increments_webhook_on_success(self):
+        before_a = notifications_attempted_total.labels(channel="webhook")._value.get()
+        before_s = notifications_sent_total.labels(channel="webhook")._value.get()
+        with patch("app.notifications.webhook_notify", return_value=True), \
              patch("app.config.NOTIFY_CHANNELS", ["webhook"]):
             from app.notifications import dispatch
             u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
             dispatch([u])
-        assert notifications_sent_total.labels(channel="webhook")._value.get() == before + 1.0
+        assert notifications_attempted_total.labels(channel="webhook")._value.get() == before_a + 1.0
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_s + 1.0
 
-    def test_increments_email_channel(self):
-        before = notifications_sent_total.labels(channel="email")._value.get()
-        with patch("app.notifications.email_notify"), \
+    def test_increments_email_on_success(self):
+        before_a = notifications_attempted_total.labels(channel="email")._value.get()
+        before_s = notifications_sent_total.labels(channel="email")._value.get()
+        with patch("app.notifications.email_notify", return_value=True), \
              patch("app.config.NOTIFY_CHANNELS", ["email"]):
             from app.notifications import dispatch
             u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
             dispatch([u])
-        assert notifications_sent_total.labels(channel="email")._value.get() == before + 1.0
+        assert notifications_attempted_total.labels(channel="email")._value.get() == before_a + 1.0
+        assert notifications_sent_total.labels(channel="email")._value.get() == before_s + 1.0
+
+    def test_webhook_failure_increments_attempted_only(self):
+        before_a = notifications_attempted_total.labels(channel="webhook")._value.get()
+        before_s = notifications_sent_total.labels(channel="webhook")._value.get()
+        with patch("app.notifications.webhook_notify", return_value=False), \
+             patch("app.config.NOTIFY_CHANNELS", ["webhook"]):
+            from app.notifications import dispatch
+            u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
+            dispatch([u])
+        assert notifications_attempted_total.labels(channel="webhook")._value.get() == before_a + 1.0
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_s
+
+    def test_email_failure_increments_attempted_only(self):
+        before_a = notifications_attempted_total.labels(channel="email")._value.get()
+        before_s = notifications_sent_total.labels(channel="email")._value.get()
+        with patch("app.notifications.email_notify", return_value=False), \
+             patch("app.config.NOTIFY_CHANNELS", ["email"]):
+            from app.notifications import dispatch
+            u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
+            dispatch([u])
+        assert notifications_attempted_total.labels(channel="email")._value.get() == before_a + 1.0
+        assert notifications_sent_total.labels(channel="email")._value.get() == before_s
+
+    def test_skipped_notifier_does_not_increment_either_counter(self):
+        """When the notifier returns None (no attempt made), neither counter moves."""
+        before_a = notifications_attempted_total.labels(channel="webhook")._value.get()
+        before_s = notifications_sent_total.labels(channel="webhook")._value.get()
+        with patch("app.notifications.webhook_notify", return_value=None), \
+             patch("app.config.NOTIFY_CHANNELS", ["webhook"]):
+            from app.notifications import dispatch
+            u = UpdateInfo("c", "s", "st", "img", "1.0", "2.0", "major", status="new")
+            dispatch([u])
+        assert notifications_attempted_total.labels(channel="webhook")._value.get() == before_a
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_s
 
     def test_no_increment_when_nothing_to_notify(self):
-        before_w = notifications_sent_total.labels(channel="webhook")._value.get()
-        before_e = notifications_sent_total.labels(channel="email")._value.get()
+        before_aw = notifications_attempted_total.labels(channel="webhook")._value.get()
+        before_sw = notifications_sent_total.labels(channel="webhook")._value.get()
+        before_ae = notifications_attempted_total.labels(channel="email")._value.get()
+        before_se = notifications_sent_total.labels(channel="email")._value.get()
         with patch("app.config.NOTIFY_CHANNELS", ["webhook", "email"]):
             from app.notifications import dispatch
             dispatch([])
-        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_w
-        assert notifications_sent_total.labels(channel="email")._value.get() == before_e
+        assert notifications_attempted_total.labels(channel="webhook")._value.get() == before_aw
+        assert notifications_sent_total.labels(channel="webhook")._value.get() == before_sw
+        assert notifications_attempted_total.labels(channel="email")._value.get() == before_ae
+        assert notifications_sent_total.labels(channel="email")._value.get() == before_se
 
 
 class TestMetricsEndpoint:
@@ -217,6 +260,11 @@ class TestMetricsEndpoint:
         resp = client.get("/metrics")
         body = resp.data.decode()
         assert "dum_notifications_sent_total" in body
+
+    def test_contains_dum_notifications_attempted_total(self, client):
+        resp = client.get("/metrics")
+        body = resp.data.decode()
+        assert "dum_notifications_attempted_total" in body
 
     def test_metric_values_reflect_last_scan(self, client):
         import re

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -172,6 +172,65 @@ class TestNotifyEmptyList:
         mock_session.post.assert_not_called()
 
 
+class TestNotifyReturnValue:
+    """notify() returns True on success, False on failure, None when not attempted."""
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_true_on_success(self, mock_session):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            assert notify([_make_update()]) is True
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_false_on_request_exception(self, mock_session):
+        import requests
+        mock_session.post.side_effect = requests.ConnectionError("refused")
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            assert notify([_make_update()]) is False
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_false_on_http_error_status(self, mock_session):
+        from requests.exceptions import HTTPError
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = HTTPError("500")
+        mock_session.post.return_value = mock_resp
+
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"), \
+             patch.object(config_mod, "NOTIFY_AUTH_TYPE", ""), \
+             patch.object(config_mod, "NOTIFY_AUTH_TOKEN", ""):
+            assert notify([_make_update()]) is False
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_none_on_dry_run(self, mock_session):
+        with patch.object(config_mod, "DRY_RUN", True), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"):
+            assert notify([_make_update()]) is None
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_none_when_no_endpoint(self, mock_session):
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", ""):
+            assert notify([_make_update()]) is None
+
+    @patch.object(http_mod, "http_session")
+    def test_returns_none_when_nothing_to_send(self, mock_session):
+        with patch.object(config_mod, "DRY_RUN", False), \
+             patch.object(config_mod, "NOTIFY_ENDPOINT", "http://hook.example.com"):
+            assert notify([]) is None
+
+
 class TestNotifyPayloadStructure:
     """Payload grouping, field removal, mismatches and warnings."""
 


### PR DESCRIPTION
## Summary
- `notifications_sent_total` over-counted during outages because dispatch() incremented it unconditionally — channel notifiers swallow their own delivery errors, so dispatch could not tell success from failure.
- Adopts the issue's preferred Option 2: keep `notifications_sent_total` as "successfully delivered" and add `notifications_attempted_total` so `attempted − sent` reflects failures.

## Changes
- `app/notifications/webhook.py`, `app/notifications/email.py`: `notify()` returns `True` on success, `False` on a delivery attempt that failed (RequestException / SMTP error), and `None` when no attempt was made (empty payload, DRY_RUN, missing endpoint or SMTP config).
- `app/notifications/__init__.py`: `dispatch()` reads the notifier return value via a small `_record()` helper — `None` skips both counters, any non-`None` increments `attempted`, truthy also increments `sent`.
- `app/metrics.py`: new `notifications_attempted_total` Counter labeled by channel, exposed at `/metrics` as `dum_notifications_attempted_total`.
- `tests/test_notifications.py`, `tests/test_email_notifications.py`: cover the new tri-state return contract for both notifiers.
- `tests/test_metrics.py`: rework `TestNotificationsSentCounter` to assert that success bumps both counters, failure bumps only `attempted`, and `None` bumps neither; assert the new metric is exposed at `/metrics`.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 496 passed locally.
- [x] Webhook returning a non-2xx (or unreachable) leaves `dum_notifications_sent_total{channel="webhook"}` unchanged while `dum_notifications_attempted_total{channel="webhook"}` increments.
- [x] Successful webhook delivery increments both counters.
- [x] DRY_RUN, missing `NOTIFY_ENDPOINT`, or missing SMTP config increments neither counter.
- [x] `GET /metrics` exposes both `dum_notifications_attempted_total` and `dum_notifications_sent_total`.