### PR TITLE
Resolve STATE_DB_PATH at call time (fix #145)

### DIFF
--- a/app/state.py
+++ b/app/state.py
@@ -8,8 +8,6 @@ from app.migrations import run_migrations
 from app.models import UpdateInfo
 from app.version import parse_tag
 
-_DB_PATH = Path(_config.STATE_DB_PATH)
-
 _SCHEMA = """\
 CREATE TABLE IF NOT EXISTS updates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -47,8 +45,9 @@ CREATE TABLE IF NOT EXISTS metadata (
 
 
 def _connect() -> sqlite3.Connection:
-    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(_DB_PATH))
+    db_path = Path(_config.STATE_DB_PATH)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(_SCHEMA)
     conn.execute(_DIGESTS_SCHEMA)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 import os
 import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,8 +15,6 @@ def _state_db_in_tmp(tmp_path):
     """Redirect the state DB to a temp directory for every test."""
     db_path = str(tmp_path / "state.db")
     with patch("app.config.STATE_DB_PATH", db_path):
-        import app.state as state_mod
-        state_mod._DB_PATH = Path(db_path)
         yield
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -565,6 +565,40 @@ class TestDigestAutoResolve:
         assert resolved[0].new_version == "1.2.0"
 
 
+class TestStateDbPathResolvedAtCallTime:
+    """Regression tests for #145: STATE_DB_PATH must be resolved on every _connect()."""
+
+    def test_save_last_check_honors_path_set_after_import(self, tmp_path):
+        new_path = tmp_path / "late_bind.db"
+        with patch("app.config.STATE_DB_PATH", str(new_path)):
+            state.save_last_check("2026-01-01T00:00:00+00:00")
+
+        assert new_path.exists()
+
+    def test_path_change_redirects_reads_and_writes(self, tmp_path):
+        first_path = tmp_path / "first.db"
+        second_path = tmp_path / "second.db"
+
+        with patch("app.config.STATE_DB_PATH", str(first_path)):
+            state.save_last_check("2026-01-01T00:00:00+00:00")
+
+        with patch("app.config.STATE_DB_PATH", str(second_path)):
+            assert state.load_last_check() is None
+            state.save_last_check("2026-02-02T00:00:00+00:00")
+            assert state.load_last_check() == "2026-02-02T00:00:00+00:00"
+
+        with patch("app.config.STATE_DB_PATH", str(first_path)):
+            assert state.load_last_check() == "2026-01-01T00:00:00+00:00"
+
+    def test_parent_directory_created_at_call_time(self, tmp_path):
+        nested = tmp_path / "nested" / "subdir" / "state.db"
+        with patch("app.config.STATE_DB_PATH", str(nested)):
+            state.save_last_check("2026-01-01T00:00:00+00:00")
+
+        assert nested.exists()
+        assert nested.parent.is_dir()
+
+
 class TestProcessScanEdgeCases:
     def test_empty_container_name(self):
         """Update with empty container_name is stored and retrieved."""


### PR DESCRIPTION
## Summary
- Fixes #145: `app/state.py` was binding the SQLite path at module import, so any later change to `STATE_DB_PATH` (e.g. tests swapping to a tmp path, dynamic config reload) was silently ignored.
- `_connect()` now re-reads `app.config.STATE_DB_PATH` on every call.

## Changes
- `app/state.py`: drop the module-level `_DB_PATH`; resolve `Path(_config.STATE_DB_PATH)` inside `_connect()` so the env-var-driven config is honored at call time.
- `tests/conftest.py`: remove the `state_mod._DB_PATH = Path(db_path)` workaround that papered over the bug in `_state_db_in_tmp`; patching `app.config.STATE_DB_PATH` is now sufficient.
- `tests/test_state.py`: add `TestStateDbPathResolvedAtCallTime` with three regression tests covering the exact reproducer from the issue, sequential path swaps, and parent-directory creation against a dynamically-resolved path.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 499 passed locally.
- [x] New regression tests in `TestStateDbPathResolvedAtCallTime` pass and would fail against the pre-fix code (path bound at import).
- [x] Existing `_state_db_in_tmp` autouse fixture still isolates each test's DB to `tmp_path` without the manual `_DB_PATH` assignment.