### PR TITLE
Cache module-level SQLite connection in state (fix #146)

### DIFF
--- a/app/state.py
+++ b/app/state.py
@@ -1,4 +1,5 @@
 import sqlite3
+import threading
 from copy import copy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,17 +45,42 @@ CREATE TABLE IF NOT EXISTS metadata (
 """
 
 
+_conn_lock = threading.Lock()
+_conn: sqlite3.Connection | None = None
+_conn_path: str | None = None
+
+
 def _connect() -> sqlite3.Connection:
-    db_path = Path(_config.STATE_DB_PATH)
+    """Return the cached module-level SQLite connection.
+
+    Schema creation and migrations run once per (process, db_path). If
+    STATE_DB_PATH changes (e.g. between tests) the old connection is closed
+    and a fresh one is opened. Callers must hold ``_conn_lock`` while using
+    the returned connection — it is shared across threads.
+    """
+    global _conn, _conn_path
+    current_path = _config.STATE_DB_PATH
+    if _conn is not None and _conn_path == current_path:
+        return _conn
+
+    if _conn is not None:
+        _conn.close()
+        _conn = None
+
+    db_path = Path(current_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute(_SCHEMA)
     conn.execute(_DIGESTS_SCHEMA)
     conn.execute(_METADATA_SCHEMA)
     run_migrations(conn)
     conn.commit()
-    return conn
+
+    _conn = conn
+    _conn_path = current_path
+    return _conn
 
 
 def process_scan(
@@ -90,8 +116,8 @@ def process_scan(
         current_versions = {}
 
     ts = scan_time.isoformat()
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         # --- upsert current findings ---
         for u in updates:
             conn.execute(
@@ -116,7 +142,6 @@ def process_scan(
             for u in updates
         }
 
-        conn.row_factory = sqlite3.Row
         active_rows = conn.execute(
             "SELECT * FROM updates WHERE resolved_at IS NULL",
         ).fetchall()
@@ -225,8 +250,6 @@ def process_scan(
             ))
 
         return result
-    finally:
-        conn.close()
 
 
 def mark_notified(updates: list[UpdateInfo], notified_time: datetime | None = None) -> None:
@@ -235,8 +258,8 @@ def mark_notified(updates: list[UpdateInfo], notified_time: datetime | None = No
         notified_time = datetime.now(timezone.utc)
 
     ts = notified_time.isoformat()
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         for u in updates:
             conn.execute(
                 """UPDATE updates SET notified_at = ?
@@ -245,28 +268,22 @@ def mark_notified(updates: list[UpdateInfo], notified_time: datetime | None = No
                 (ts, u.container_name, u.image, u.new_version, u.update_type),
             )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def get_active_updates() -> list[dict]:
     """Return all non-resolved update rows as dicts."""
-    conn = _connect()
-    try:
-        conn.row_factory = sqlite3.Row
+    with _conn_lock:
+        conn = _connect()
         rows = conn.execute(
             "SELECT * FROM updates WHERE resolved_at IS NULL ORDER BY first_seen_at"
         ).fetchall()
         return [dict(r) for r in rows]
-    finally:
-        conn.close()
 
 
 def get_all_updates() -> list[dict]:
     """Return all update rows (active and resolved) as dicts with a 'status' field."""
-    conn = _connect()
-    try:
-        conn.row_factory = sqlite3.Row
+    with _conn_lock:
+        conn = _connect()
         rows = conn.execute(
             "SELECT * FROM updates ORDER BY first_seen_at"
         ).fetchall()
@@ -281,33 +298,27 @@ def get_all_updates() -> list[dict]:
                 d["status"] = "new"
             result.append(d)
         return result
-    finally:
-        conn.close()
 
 
 def save_last_check(iso_timestamp: str) -> None:
     """Persist the last scan timestamp to the database."""
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) VALUES ('last_check', ?)",
             (iso_timestamp,),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def load_last_check() -> str | None:
     """Load the persisted last scan timestamp from the database."""
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         row = conn.execute(
             "SELECT value FROM metadata WHERE key = 'last_check'"
         ).fetchone()
         return row[0] if row else None
-    finally:
-        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -316,15 +327,13 @@ def load_last_check() -> str | None:
 
 def get_stored_digest(image: str, tag: str) -> str | None:
     """Return the previously stored digest for (image, tag), or None."""
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         row = conn.execute(
             "SELECT digest FROM digests WHERE image = ? AND tag = ?",
             (image, tag),
         ).fetchone()
         return row[0] if row else None
-    finally:
-        conn.close()
 
 
 def store_digest(image: str, tag: str, digest: str, timestamp: datetime | None = None) -> None:
@@ -332,12 +341,10 @@ def store_digest(image: str, tag: str, digest: str, timestamp: datetime | None =
     if timestamp is None:
         timestamp = datetime.now(timezone.utc)
     ts = timestamp.isoformat()
-    conn = _connect()
-    try:
+    with _conn_lock:
+        conn = _connect()
         conn.execute(
             "INSERT OR REPLACE INTO digests (image, tag, digest, updated_at) VALUES (?, ?, ?, ?)",
             (image, tag, digest, ts),
         )
         conn.commit()
-    finally:
-        conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,18 @@ import pytest
 
 from app import http as http_mod
 from app import main as main_mod
+from app import state as state_mod
 
 
 @pytest.fixture(autouse=True)
 def _state_db_in_tmp(tmp_path):
     """Redirect the state DB to a temp directory for every test."""
     db_path = str(tmp_path / "state.db")
+    # Drop any cached connection from a prior test so each test starts cold.
+    if state_mod._conn is not None:
+        state_mod._conn.close()
+    state_mod._conn = None
+    state_mod._conn_path = None
     with patch("app.config.STATE_DB_PATH", db_path):
         yield
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,5 +1,6 @@
 """Unit tests for app.state — SQLite state persistence."""
 
+import sqlite3
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -617,3 +618,119 @@ class TestProcessScanEdgeCases:
         result = state.process_scan([u], scan_time=t)
         assert len(result) == 1
         assert result[0].image == ""
+
+
+class TestConnectionCaching:
+    """Regression tests for #146: connection + schema + migrations reused across calls."""
+
+    def test_schema_and_migrations_run_once_for_repeated_calls(self):
+        """run_migrations is invoked at most once across many state operations."""
+        u = _make_update()
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        with patch("app.state.run_migrations", wraps=state.run_migrations) as spy:
+            state.process_scan([u], scan_time=t)
+            state.get_active_updates()
+            state.get_all_updates()
+            state.save_last_check("2026-01-01T00:00:00+00:00")
+            state.load_last_check()
+            state.store_digest("nginx", "latest", "sha256:abc")
+            state.get_stored_digest("nginx", "latest")
+            state.mark_notified([u], notified_time=t)
+            state.process_scan([u], scan_time=t)
+
+        assert spy.call_count == 1
+
+    def test_connection_is_reused_across_calls(self):
+        """All state operations share the same sqlite3 connection object."""
+        state.save_last_check("2026-01-01T00:00:00+00:00")
+        first = state._conn
+        assert first is not None
+
+        state.load_last_check()
+        state.get_active_updates()
+        state.get_all_updates()
+        state.store_digest("nginx", "latest", "sha256:abc")
+        state.get_stored_digest("nginx", "latest")
+
+        assert state._conn is first
+
+    def test_path_change_closes_and_replaces_connection(self, tmp_path):
+        """Switching STATE_DB_PATH closes the old connection and opens a new one."""
+        first_path = tmp_path / "first.db"
+        second_path = tmp_path / "second.db"
+
+        with patch("app.config.STATE_DB_PATH", str(first_path)):
+            state.save_last_check("2026-01-01T00:00:00+00:00")
+            first_conn = state._conn
+            assert state._conn_path == str(first_path)
+
+        with patch("app.config.STATE_DB_PATH", str(second_path)):
+            state.save_last_check("2026-02-02T00:00:00+00:00")
+            assert state._conn is not first_conn
+            assert state._conn_path == str(second_path)
+
+        # The first connection was closed when we switched paths.
+        with pytest.raises(sqlite3.ProgrammingError):
+            first_conn.execute("SELECT 1")
+
+    def test_concurrent_access_is_thread_safe(self):
+        """Many threads hammering state functions in parallel do not corrupt state."""
+        import threading
+
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        errors: list[BaseException] = []
+
+        def worker(idx: int) -> None:
+            try:
+                u = _make_update(
+                    container_name=f"c{idx}",
+                    image=f"img{idx}",
+                    new_version=f"1.{idx}.0",
+                )
+                for _ in range(5):
+                    state.process_scan([u], scan_time=t0)
+                    state.save_last_check(t0.isoformat())
+                    state.load_last_check()
+                    state.store_digest(f"img{idx}", "latest", f"sha256:{idx}")
+                    state.get_stored_digest(f"img{idx}", "latest")
+                    state.get_active_updates()
+                    state.get_all_updates()
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+        assert errors == []
+        # One row per worker survived the concurrent writes.
+        active = state.get_active_updates()
+        assert len(active) == 8
+        assert {row["container_name"] for row in active} == {f"c{i}" for i in range(8)}
+
+    def test_connection_uses_check_same_thread_false(self):
+        """Cached connection must allow cross-thread reuse."""
+        import threading
+
+        state.save_last_check("2026-01-01T00:00:00+00:00")
+        conn = state._conn
+        assert conn is not None
+
+        errors: list[BaseException] = []
+
+        def use_from_other_thread() -> None:
+            try:
+                state.load_last_check()
+            except BaseException as exc:
+                errors.append(exc)
+
+        th = threading.Thread(target=use_from_other_thread)
+        th.start()
+        th.join()
+
+        assert errors == []
+        # Cached connection wasn't swapped out — it really was reused cross-thread.
+        assert state._conn is conn


### PR DESCRIPTION
## Summary
- Every state op was opening a new SQLite connection and re-running `PRAGMA journal_mode=WAL`, three `CREATE TABLE IF NOT EXISTS` statements, and `run_migrations` — dozens of times per scan, all wasted after the first call.
- Cache a module-level connection keyed by `STATE_DB_PATH`; schema + migrations now run exactly once per process/path.

## Changes
- `app/state.py`: replace per-call `_connect()` with a cached `_conn` + `_conn_path` pair guarded by `_conn_lock`. Opens the connection with `check_same_thread=False`, sets `row_factory = sqlite3.Row` once at init, and only re-runs schema/migrations when the path changes (preserving #145 behavior and the per-test fixture). All public functions (`process_scan`, `mark_notified`, `get_active_updates`, `get_all_updates`, `save_last_check`, `load_last_check`, `get_stored_digest`, `store_digest`) now wrap their DB work in `with _conn_lock:` instead of opening/closing per call.
- `tests/conftest.py`: the autouse `_state_db_in_tmp` fixture also closes any cached connection from a prior test so each test starts cold.
- `tests/test_state.py`: new `TestConnectionCaching` class with five tests covering reuse, one-shot migrations, path-change reinitialization, thread safety, and cross-thread connection access.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 504 passed
- [x] `run_migrations` invoked only once across 9 mixed state ops
- [x] Same `sqlite3.Connection` object reused across calls
- [x] Switching `STATE_DB_PATH` closes the old connection and opens a new one
- [x] 8 threads × 5 iterations of mixed ops run without errors or row corruption
- [x] Existing #145 path-resolution regression tests still pass