### PR TITLE
Drop unused update_state import from dashboard (fix #148)

### DIFF
--- a/app/dashboard.py
+++ b/app/dashboard.py
@@ -8,7 +8,7 @@ from flask import Flask, Response, jsonify, render_template
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 import app.config as _config
-from app.health import update_state, _state, _state_lock, _build_response
+from app.health import _state, _state_lock, _build_response
 from app.state import get_all_updates
 
 _scan_trigger = threading.Event()


### PR DESCRIPTION
## Summary
- Remove the unused `update_state` symbol from the `app.health` import in [app/dashboard.py:11](app/dashboard.py#L11).
- Clarifies that the dashboard is a read-only consumer of health state and never mutates it.

## Changes
- `app/dashboard.py`: import line now pulls only `_state`, `_state_lock`, and `_build_response` — the three names actually referenced in the module.

## Test plan
- [x] Full test suite passes (`.venv/bin/python -m pytest tests/ -v`) — 512 passed
- [x] `grep update_state app/dashboard.py` returns no matches, confirming the symbol was never used

Closes #148