### PR TITLE
Drop updates for removed containers (fix #165)

### DIFF
--- a/app/scanner.py
+++ b/app/scanner.py
@@ -117,6 +117,19 @@ def run_check() -> None:
         containers = client.containers.list()
         _config.log.info(f"Running containers: {len(containers)}")
 
+        # Full set of container names Docker currently knows about (running and
+        # stopped).  Used to distinguish a *removed* container — whose pending
+        # update should be dropped — from one that merely failed to scan this
+        # cycle.  If the listing fails, fall back to None so removal cleanup is
+        # skipped rather than risking deletion on incomplete data.
+        try:
+            existing_containers: set[str] | None = {
+                c.name or "" for c in client.containers.list(all=True)
+            }
+        except DockerException as exc:
+            _config.log.warning(f"Could not list all containers: {exc} — skipping removal cleanup")
+            existing_containers = None
+
         # Cache tag lists — keyed by (image_name, current_tag) so that the
         # DockerHub early-stop optimisation doesn't miss tags when two containers
         # run different versions of the same image.
@@ -463,6 +476,7 @@ def run_check() -> None:
             all_updates, scan_time,
             current_versions=monitored_versions,
             running_digests=running_digests,
+            existing_containers=existing_containers,
         )
 
         # Deduplicate: keep only the highest new_version per (container, image, update_type).

--- a/app/state.py
+++ b/app/state.py
@@ -88,6 +88,7 @@ def process_scan(
     scan_time: datetime | None = None,
     current_versions: dict[tuple[str, str], tuple[str, str]] | None = None,
     running_digests: dict[tuple[str, str], list[str]] | None = None,
+    existing_containers: set[str] | None = None,
 ) -> list[UpdateInfo]:
     """Upsert scan results, resolve or delete absent entries, return updates with status.
 
@@ -107,8 +108,13 @@ def process_scan(
     a digest update entry is resolved if the container's running image already contains
     the stored (new) digest — meaning the user repulled and restarted the container.
 
-    Entries for containers *not* in *current_versions* are left untouched (the
-    container may have been temporarily unreachable).
+    *existing_containers* is the set of container names Docker currently knows about
+    (running *and* stopped).  When provided, active entries whose container name is
+    absent from this set are **deleted** — the container has been removed, so its
+    pending update is no longer relevant and must not keep showing up in the overview.
+
+    Entries for containers that still exist but are *not* in *current_versions* are
+    left untouched (the container may have been temporarily unreachable).
     """
     if scan_time is None:
         scan_time = datetime.now(timezone.utc)
@@ -152,6 +158,14 @@ def process_scan(
             key = (row["container_name"], row["image"], row["current_version"], row["update_type"])
             if key in current_keys:
                 continue  # still detected, already upserted
+
+            # Container was removed entirely — forget its pending update so it
+            # stops appearing in the overview.  A removed container differs from a
+            # transiently unreachable one: it is genuinely gone, so the update is
+            # no longer actionable.
+            if existing_containers is not None and row["container_name"] not in existing_containers:
+                conn.execute("DELETE FROM updates WHERE id = ?", (row["id"],))
+                continue
 
             cv_key = (row["container_name"], row["image"])
             if cv_key not in current_versions:

--- a/tests/test_run_check.py
+++ b/tests/test_run_check.py
@@ -792,6 +792,97 @@ class TestRunCheckDeduplication:
         assert len(updates) == 2
 
 
+class TestRunCheckRemovedContainer:
+    """End-to-end removal cleanup (fix #165)."""
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_removed_container_update_dropped(self, mock_docker, mock_token, mock_fetch):
+        """A pending update disappears once its container is removed."""
+        from app.state import get_all_updates
+
+        container = _make_container(
+            "app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        client = MagicMock()
+        mock_docker.from_env.return_value = client
+        client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+        assert len(get_all_updates()) == 1  # update recorded while running
+
+        # Container removed: Docker no longer lists it (running or otherwise).
+        client.containers.list.return_value = []
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        assert get_all_updates() == []  # update dropped
+
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_present_container_transient_failure_keeps_update(self, mock_docker, mock_token):
+        """A still-running container whose scan fails keeps its pending update."""
+        from app.state import get_all_updates
+
+        container = _make_container(
+            "app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        client = MagicMock()
+        mock_docker.from_env.return_value = client
+        client.containers.list.return_value = [container]
+
+        # Scan 1: update found and recorded.
+        with patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"]), \
+             patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+        assert len(get_all_updates()) == 1
+
+        # Scan 2: container still present, but registry returns no tags (transient).
+        with patch("app.scanner.fetch_all_tags", return_value=[]), \
+             patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # Update preserved — the container still exists, the scan just failed.
+        assert len(get_all_updates()) == 1
+
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_all_listing_failure_skips_cleanup(self, mock_docker, mock_token, mock_fetch):
+        """If listing all containers fails, removal cleanup is skipped (entry kept)."""
+        from docker.errors import APIError
+        from app.state import get_all_updates
+
+        container = _make_container(
+            "app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        client = MagicMock()
+        mock_docker.from_env.return_value = client
+        client.containers.list.return_value = [container]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+        assert len(get_all_updates()) == 1
+
+        # Container removed AND the all=True listing errors out — degrade safely.
+        def _list(*args, **kwargs):
+            if kwargs.get("all"):
+                raise APIError("boom")
+            return []
+
+        client.containers.list.side_effect = _list
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # Cleanup skipped rather than risking deletion on incomplete data.
+        assert len(get_all_updates()) == 1
+
+
 class TestMainEdgeCases:
     """Edge cases in main()."""
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -204,6 +204,102 @@ class TestResolve:
         assert len(state.get_all_updates()) == 1
 
 
+class TestRemovedContainer:
+    """Removed containers (fix #165): their pending updates must be dropped."""
+
+    def test_removed_container_update_deleted(self):
+        """An active update is deleted when its container no longer exists."""
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        # Container "web" was removed — it isn't in the existing set anymore.
+        result = state.process_scan([], scan_time=t2, existing_containers=set())
+
+        assert result == []
+        assert len(state.get_active_updates()) == 0
+        assert len(state.get_all_updates()) == 0
+
+    def test_present_but_unscanned_container_left_alone(self):
+        """A still-present container that failed to scan keeps its update."""
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        # Container still exists but wasn't scanned (not in current_versions) —
+        # e.g. registry was temporarily unreachable. Entry must survive.
+        result = state.process_scan([], scan_time=t2, existing_containers={"web"})
+
+        known = [r for r in result if r.status == "known"]
+        assert len(known) == 1
+        assert len(state.get_active_updates()) == 1
+
+    def test_removed_one_keeps_another(self):
+        """Only the removed container's update is dropped; present ones survive."""
+        u1 = _make_update()  # container "web"
+        u2 = _make_update(container_name="db", image="postgres",
+                          current_version="15.0.0", new_version="15.1.0",
+                          update_type="patch")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u1, u2], scan_time=t1)
+        # "web" removed, "db" still present but unscanned this cycle.
+        result = state.process_scan([], scan_time=t2, existing_containers={"db"})
+
+        remaining = state.get_all_updates()
+        assert len(remaining) == 1
+        assert remaining[0]["container_name"] == "db"
+        assert all(r.container_name != "web" for r in result)
+
+    def test_removed_container_not_notified(self):
+        """A removed container's update is neither resolved nor returned for notification."""
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        result1 = state.process_scan([u], scan_time=t1)
+        state.mark_notified(result1, notified_time=t1)
+        result = state.process_scan([], scan_time=t2, existing_containers=set())
+
+        # Nothing returned → nothing to notify, and no lingering "resolved" record.
+        assert result == []
+        assert state.get_all_updates() == []
+
+    def test_default_none_preserves_old_behavior(self):
+        """Without existing_containers, absent entries are left untouched."""
+        u = _make_update()
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        # No existing_containers passed — cannot tell removed from unreachable.
+        result = state.process_scan([], scan_time=t2)
+
+        known = [r for r in result if r.status == "known"]
+        assert len(known) == 1
+        assert len(state.get_active_updates()) == 1
+
+    def test_present_container_still_resolves(self):
+        """Passing existing_containers does not break normal resolution."""
+        u = _make_update(new_version="1.1.0", update_type="minor")
+        t1 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        t2 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+        state.process_scan([u], scan_time=t1)
+        # Container present and updated to 1.1.0 → resolved, not deleted.
+        cv = {("web", "nginx"): ("1.1.0", _PAT)}
+        result = state.process_scan(
+            [], scan_time=t2, current_versions=cv, existing_containers={"web"}
+        )
+
+        resolved = [r for r in result if r.status == "resolved"]
+        assert len(resolved) == 1
+        assert len(state.get_active_updates()) == 0
+
+
 class TestQueryByStatus:
     def test_get_active_excludes_resolved(self):
         u = _make_update()


### PR DESCRIPTION
## Summary
- Removed containers no longer keep showing a stale "update available" flag in the overview.
- `process_scan` now distinguishes a *removed* container from one that merely failed to scan this cycle, so pending updates for deleted containers are cleaned up while transient scan failures are left untouched.

## Changes
- `app/state.py`: Added `existing_containers: set[str] | None` param to `process_scan`. Active entries whose container name is absent from that set are deleted (the container is genuinely gone). Entries for still-present-but-unscanned containers remain untouched, preserving the temporary-unreachable safety net.
- `app/scanner.py`: `run_check` builds `existing_containers` from `client.containers.list(all=True)` (so a merely *stopped* container isn't treated as removed) and passes it to `process_scan`. Wrapped in `try/except DockerException` → falls back to `None` (skip cleanup) if the listing fails, so removal never runs on incomplete data.
- `tests/test_state.py`: `TestRemovedContainer` — removed→deleted, present-but-unscanned→kept, mixed, not-notified, `None` default preserves old behavior, present container still resolves.
- `tests/test_run_check.py`: `TestRunCheckRemovedContainer` — end-to-end drop on removal, transient failure keeps update, `all=True` listing failure safely skips cleanup.

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 522 passed
- [x] Update recorded while a container runs is dropped after the container is removed
- [x] A still-running container whose scan fails (no tags returned) keeps its pending update
- [x] A failed `containers.list(all=True)` skips cleanup instead of deleting on incomplete data