### PR TITLE
Survive uninspectable container images (fix #163)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,19 @@ signal.signal(signal.SIGTERM, _handle_signal)
 signal.signal(signal.SIGINT, _handle_signal)
 
 
+def _safe_run_check() -> None:
+    """Run one update check, containing any failure so the scheduler survives.
+
+    An unhandled exception escaping run_check() would crash the process and, in a
+    container, trigger an endless restart loop (issue #163). Instead we log the
+    error and keep the monitor running; the next scheduled scan retries.
+    """
+    try:
+        run_check()
+    except Exception as exc:
+        _config.log.error(f"Update check failed: {exc}", exc_info=True)
+
+
 def main() -> None:
     _config.log.info("Docker Update Monitor started")
     if _config.DRY_RUN:
@@ -49,7 +62,7 @@ def main() -> None:
 
     if _config.RUN_ON_STARTUP:
         _config.log.info("Running initial check on startup")
-        run_check()
+        _safe_run_check()
         if shutdown_requested:
             _config.log.info("Shutting down gracefully")
             sys.exit(0)
@@ -69,7 +82,7 @@ def main() -> None:
             if _scan_trigger.is_set():
                 _scan_trigger.clear()
                 _config.log.info("Manual scan triggered via dashboard")
-                run_check()
+                _safe_run_check()
                 triggered = True
                 if shutdown_requested:
                     break
@@ -91,7 +104,7 @@ def main() -> None:
 
         # Run scheduled check if the sleep loop completed normally (not a manual trigger)
         if not triggered:
-            run_check()
+            _safe_run_check()
 
             if shutdown_requested:
                 break

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -146,6 +146,24 @@ def run_check() -> None:
         for container in containers:
             container_name: str = container.name or ""
             labels  = container.labels
+
+            # Resolve the container's image once. Accessing container.image lazily
+            # calls the Docker API (images.get); if the underlying image was pruned
+            # or removed out from under a still-listed container it raises
+            # ImageNotFound. Contain that failure here so a single broken container
+            # is reported but can't crash the whole scan (fix #163).
+            try:
+                image_obj = container.image
+            except (DockerException, requests.RequestException) as exc:
+                image_hint = container.attrs.get("Config", {}).get("Image", "") or ""
+                msg = f"Could not inspect image: {exc}"
+                _config.log.error(f"  [{container_name}] {msg} — skipping")
+                all_warnings.append(ScanWarning(
+                    container_name=container_name, image=image_hint,
+                    level="error", message=msg,
+                ))
+                continue
+
             mode    = labels.get(f"{_config.LABEL_PREFIX}.mode", "").lower()
             pattern = labels.get(f"{_config.LABEL_PREFIX}.tag-regex")
 
@@ -153,8 +171,8 @@ def run_check() -> None:
                 _config.log.debug(f"  [{container_name}] No '{_config.LABEL_PREFIX}.tag-regex' label — skipping")
                 # Determine image for display
                 skip_image = ""
-                if container.image.tags:
-                    skip_image = container.image.tags[0]
+                if image_obj.tags:
+                    skip_image = image_obj.tags[0]
                 else:
                     skip_image = container.attrs.get("Config", {}).get("Image", "")
                 skip_stack = (
@@ -195,8 +213,8 @@ def run_check() -> None:
 
             # Resolve full image reference
             image_ref = None
-            if container.image.tags:
-                image_ref = container.image.tags[0]
+            if image_obj.tags:
+                image_ref = image_obj.tags[0]
             else:
                 # Fallback: read from container attrs
                 image_ref = container.attrs.get("Config", {}).get("Image", "")
@@ -236,7 +254,7 @@ def run_check() -> None:
                 # Explicit digest mode: compare the local running image digest (RepoDigests)
                 # against the remote registry digest via HEAD request.  Works on first scan —
                 # no need for a silent storage phase.
-                repo_digests = container.image.attrs.get("RepoDigests") or []
+                repo_digests = image_obj.attrs.get("RepoDigests") or []
                 local_digest = _extract_local_digest(repo_digests)
 
                 if not local_digest:
@@ -272,7 +290,7 @@ def run_check() -> None:
                     # is unchanged before reporting an update.
                     platform_match = False
                     try:
-                        image_attrs = container.image.attrs or {}
+                        image_attrs = image_obj.attrs or {}
                         container_os = image_attrs.get("Os", "") or ""
                         container_arch = image_attrs.get("Architecture", "") or ""
                         if container_os and container_arch:
@@ -401,7 +419,7 @@ def run_check() -> None:
                 # auto-resolution can compare against the running image's RepoDigests.
                 monitored_versions[(container_name, image_name)] = (current_tag, pattern)
                 running_digests[(container_name, image_name)] = (
-                    container.image.attrs.get("RepoDigests") or []
+                    image_obj.attrs.get("RepoDigests") or []
                 )
                 continue
 
@@ -414,7 +432,7 @@ def run_check() -> None:
             container_arch: str = ""
             if check_arch:
                 try:
-                    image_attrs = container.image.attrs or {}
+                    image_attrs = image_obj.attrs or {}
                     container_os = image_attrs.get("Os", "") or ""
                     container_arch = image_attrs.get("Architecture", "") or ""
                     if not container_os or not container_arch:

--- a/tests/test_run_check.py
+++ b/tests/test_run_check.py
@@ -1,7 +1,7 @@
 """Unit tests for run_check() — Docker connection, container processing, and main() edge cases."""
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 
 from app import config as config_mod
@@ -20,6 +20,27 @@ def _make_container(name, image_tag, labels, has_image_tags=True):
     else:
         c.image.tags = []
     c.attrs = {"Config": {"Image": image_tag}}
+    return c
+
+
+def _make_pruned_container(name, image_tag, labels):
+    """Create a container mock whose backing image was pruned.
+
+    Accessing ``.image`` raises ``docker.errors.ImageNotFound`` — exactly what the
+    Docker SDK does when its lazy ``images.get()`` lookup returns a 404 (issue #163).
+    A dedicated MagicMock subclass keeps the raising property off the shared
+    MagicMock class so it can't leak into other containers/tests.
+    """
+    from docker.errors import ImageNotFound
+
+    class _PrunedContainer(MagicMock):
+        pass
+
+    c = _PrunedContainer()
+    c.name = name
+    c.labels = labels
+    c.attrs = {"Config": {"Image": image_tag}}
+    type(c).image = PropertyMock(side_effect=ImageNotFound(f"No such image: {image_tag}"))
     return c
 
 
@@ -379,6 +400,65 @@ class TestRunCheckContainerProcessing:
 
         assert "Invalid tag-regex" in caplog.text
         mock_fetch.assert_not_called()
+
+
+class TestRunCheckImageNotFound:
+    """Resilience when a container's image can no longer be inspected (fix #163)."""
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_pruned_image_reported_not_crashed(
+        self, mock_docker, mock_token, mock_fetch, mock_notify, caplog
+    ):
+        """A container whose image was pruned is reported as an error, not crashed on."""
+        import logging
+
+        pruned = _make_pruned_container(
+            "pruned-app", "ghost:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [pruned]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""), caplog.at_level(logging.ERROR):
+            run_check()  # must not raise — previously this crashed the process
+
+        assert "Could not inspect image" in caplog.text
+        # The scan still completed end-to-end.
+        mock_notify.assert_called_once()
+
+    @patch("app.scanner.notify")
+    @patch("app.scanner.fetch_all_tags", return_value=["1.0.0", "2.0.0"])
+    @patch("app.scanner.get_dockerhub_token", return_value="token")
+    @patch("app.scanner.docker")
+    def test_pruned_image_does_not_block_other_containers(
+        self, mock_docker, mock_token, mock_fetch, mock_notify
+    ):
+        """A broken container must not stop healthy containers from being scanned."""
+        pruned = _make_pruned_container(
+            "pruned-app", "ghost:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        healthy = _make_container(
+            "healthy-app", "nginx:1.0.0",
+            {"docker-update-monitor.tag-regex": r"^(\d+)\.(\d+)\.(\d+)$"},
+        )
+        mock_client = MagicMock()
+        mock_docker.from_env.return_value = mock_client
+        mock_client.containers.list.return_value = [pruned, healthy]
+
+        with patch.object(config_mod, "GITHUB_TOKEN", ""):
+            run_check()
+
+        # The healthy container was scanned and its update reported despite the
+        # pruned one appearing first in the list.
+        mock_fetch.assert_called_once()
+        updates = mock_notify.call_args[0][0]
+        assert [u.container_name for u in updates] == ["healthy-app"]
+        assert updates[0].new_version == "2.0.0"
 
 
 class TestRunCheckCooldown:
@@ -891,6 +971,17 @@ class TestMainEdgeCases:
              pytest.raises(SystemExit) as exc_info:
             main_mod.main()
         assert exc_info.value.code == 1
+
+    def test_safe_run_check_swallows_exceptions(self, caplog):
+        """A crashing run_check() is logged but never propagates out of the scheduler (fix #163)."""
+        import logging
+
+        with patch("app.main.run_check", side_effect=RuntimeError("boom")), \
+             caplog.at_level(logging.ERROR):
+            main_mod._safe_run_check()  # must not raise
+
+        assert "Update check failed" in caplog.text
+        assert "boom" in caplog.text
 
     @patch("app.main.run_check")
     def test_dry_run_logs_mode(self, mock_run_check, caplog):


### PR DESCRIPTION
## Summary
- Fixes #163: a pruned image caused `container.image` to raise `ImageNotFound`, crashing the process into a container restart loop.
- One broken container is now reported as an error and skipped; the scan continues for all other containers, and any unexpected scan failure is contained so the scheduler keeps running.

## Changes
- `app/scanner.py`: resolve `container.image` **once** per container inside a guarded `try/except (DockerException, requests.RequestException)`. On failure it logs an error, records an `error`-level `ScanWarning` (surfaced via metrics/health/dashboard), and continues to the next container. Reusing the resolved image object also removes up to 5 redundant Docker API calls per container.
- `app/main.py`: add `_safe_run_check()`, a top-level guard that logs (with traceback) any exception escaping `run_check()` instead of letting it kill the scheduler; used at all three call sites (startup / manual trigger / scheduled). `run_check()` still propagates errors when called directly, preserving existing behaviour.
- `tests/test_run_check.py`: new tests plus a `_make_pruned_container` helper whose `.image` faithfully raises `ImageNotFound`.

## Test plan
- [x] Full test suite passes (`pytest tests/ -v`) — 525 passed
- [x] Pruned-image container is reported (not crashed on) and the scan completes
- [x] A broken container first in the list does not block a healthy container from being scanned/reported
- [x] `_safe_run_check()` swallows and logs a crashing `run_check()` without propagating